### PR TITLE
Implement minimal hydrology and basin utilities

### DIFF
--- a/wmf_heavy/wmfv2.py
+++ b/wmf_heavy/wmfv2.py
@@ -35,10 +35,23 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 USE_PY = True
 
 if USE_PY:
-    from wmf_py.cu_py.basics import *  # noqa: F403
-    from wmf_py.cu_py.streams import *  # noqa: F403
-    from wmf_py.cu_py.metrics import *  # noqa: F403
-    from wmf_py.models_py.core import *  # noqa: F403
+    from wmf_py.cu_py.basics import (
+        basin_2map,
+        basin_acum,
+        basin_cut,
+        basin_find,
+        basin_map2basin,
+        dir_reclass_opentopo,
+        dir_reclass_rwatershed,
+    )
+    from wmf_py.models_py.core import ModelParams, ModelState, shia_v1
+    # Intentar importar módulos legacy para funcionalidades aún no
+    # portadas. Si no están disponibles simplemente se omiten.
+    try:  # pragma: no cover - depende de entorno
+        from cu import *  # noqa: F401,F403
+        from models import *  # noqa: F401,F403
+    except Exception:  # pragma: no cover - fallback
+        pass
 else:
     from cu import *  # Módulo de funciones de cuencas (Fortran/C o Python)  # noqa: F401,F403
     from models import *  # Módulo de simulación hidrológica  # noqa: F401,F403

--- a/wmf_py/cu_py/basics.py
+++ b/wmf_py/cu_py/basics.py
@@ -1,27 +1,96 @@
-"""Basic basin processing utilities."""
+"""Basic basin processing utilities.
+
+This module provides minimal implementations of a few basin-related
+functions required by :mod:`wmfv2`.  The algorithms are deliberately
+simple and mostly act as placeholders until the full functionality from
+the original Fortran code is ported.
+"""
+
 from __future__ import annotations
 
-from typing import Dict, Tuple, Any
+from typing import Any, Dict, Tuple
 
 try:  # NumPy optional for stubs
     import numpy as np
 except ModuleNotFoundError:  # pragma: no cover
     np = Any  # type: ignore
 
+# Mapping of D8 codes to row/column offsets following a common convention
+_D8 = {
+    1: (0, 1),  # East
+    2: (-1, 1),  # North East
+    3: (-1, 0),  # North
+    4: (-1, -1),  # North West
+    5: (0, -1),  # West
+    6: (1, -1),  # South West
+    7: (1, 0),  # South
+    8: (1, 1),  # South East
+}
 
-def dir_reclass_opentopo(flowdir: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Reclassify OpenTopo flow directions."""
-    return flowdir
+
+def dir_reclass_opentopo(flowdir: np.ndarray) -> np.ndarray:
+    """Reclassify OpenTopo flow directions.
+
+    Currently the function returns the input unchanged because the
+    internal convention follows the D8 codes used by OpenTopo.  A full
+    mapping table may be added in the future.
+    """
+
+    return flowdir.copy()
 
 
-def dir_reclass_rwatershed(flowdir: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Reclassify r.watershed flow directions."""
-    return flowdir
+def dir_reclass_rwatershed(flowdir: np.ndarray) -> np.ndarray:
+    """Reclassify ``r.watershed`` flow directions.
+
+    The present MVP assumes the incoming array already uses the internal
+    D8 numbering and simply returns a copy.  A detailed reclassification
+    may be implemented later.  See :func:`dir_reclass_opentopo`.
+    """
+
+    return flowdir.copy()
 
 
-def basin_acum(flowdir: np.ndarray, mask: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Compute upstream cell accumulation."""
-    return mask
+def basin_acum(flowdir: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Compute a simple upstream cell accumulation.
+
+    Parameters
+    ----------
+    flowdir : ndarray
+        Array of D8 flow directions encoded with integers 1--8.
+    mask : ndarray of bool
+        Basin mask where ``True`` denotes active cells.
+
+    Returns
+    -------
+    ndarray
+        Accumulated upstream cell counts.  Cells outside the mask return
+        zero.  The algorithm is a naive recursive computation and is not
+        optimised for large grids.
+    """
+
+    ny, nx = flowdir.shape
+    acc = np.zeros_like(flowdir, dtype=float)
+
+    def _acc(r: int, c: int) -> float:
+        if not mask[r, c]:
+            return 0.0
+        if acc[r, c] > 0:
+            return acc[r, c]
+        total = 1.0
+        for dr, dc in _D8.values():
+            rr, cc = r - dr, c - dc
+            if 0 <= rr < ny and 0 <= cc < nx and mask[rr, cc]:
+                off = _D8.get(flowdir[rr, cc])
+                if off and rr + off[0] == r and cc + off[1] == c:
+                    total += _acc(rr, cc)
+        acc[r, c] = total
+        return total
+
+    for r in range(ny):
+        for c in range(nx):
+            _acc(r, c)
+
+    return acc
 
 
 def basin_find(
@@ -33,9 +102,21 @@ def basin_find(
     dy: float,
     ncols: int,
     nrows: int,
-) -> Tuple[int, int]:  # pragma: no cover - stub
-    """Locate array indices given coordinates."""
-    return 0, 0
+) -> Tuple[int, int]:
+    """Locate array indices given map coordinates.
+
+    Coordinates are given in metres and refer to the lower-left corner of
+    the raster (``xll``, ``yll``).  The returned indices follow the
+    ``(row, col)`` convention with the origin at the lower-left cell.  A
+    :class:`ValueError` is raised if the point lies outside the raster
+    bounds.
+    """
+
+    col = int((x - xll) / dx)
+    row = int((y - yll) / dy)
+    if not (0 <= col < ncols and 0 <= row < nrows):
+        raise ValueError("point outside raster bounds")
+    return row, col
 
 
 def basin_cut(
@@ -43,9 +124,18 @@ def basin_cut(
     outlet_rc: Tuple[int, int],
     flowdir: np.ndarray,
     mask: np.ndarray,
-) -> Dict[str, np.ndarray]:  # pragma: no cover - stub
-    """Cut a basin mask from a DEM."""
-    return {"dem": dem, "mask": mask}
+) -> Dict[str, np.ndarray]:
+    """Apply a basin mask to DEM and flow directions.
+
+    This is a minimal implementation that simply clips the provided
+    arrays with the boolean ``mask``.  It does **not** perform an actual
+    delineation following ``flowdir``; that behaviour is left for a future
+    version.
+    """
+
+    dem_cut = np.where(mask, dem, np.nan)
+    flowdir_cut = np.where(mask, flowdir, 0)
+    return {"dem": dem_cut, "flowdir": flowdir_cut, "mask": mask}
 
 
 def basin_2map(
@@ -57,11 +147,18 @@ def basin_2map(
     yll: float,
     dx: float,
     dy: float,
-) -> np.ndarray:  # pragma: no cover - stub
-    """Map basin values to a regular grid."""
+) -> np.ndarray:
+    """Map basin values to a regular grid.
+
+    The current placeholder simply reshapes ``values`` to ``(nrows, ncols)``.
+    The coordinate arguments are accepted for API compatibility and will
+    be used once a proper basin↔map conversion is implemented.
+    """
+
     return values.reshape((nrows, ncols))
 
 
-def basin_map2basin(values_map: np.ndarray, mask_basin: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Extract basin values from a map."""
+def basin_map2basin(values_map: np.ndarray, mask_basin: np.ndarray) -> np.ndarray:
+    """Extract basin values from a map using a boolean mask."""
+
     return values_map[mask_basin.astype(bool)]

--- a/wmf_py/models_py/core.py
+++ b/wmf_py/models_py/core.py
@@ -1,12 +1,17 @@
 """Core hydrological models in Python.
 
 This module provides dataclass containers for model parameters and state,
-and a Python implementation stub for :func:`shia_v1`.
+and a minimal Python implementation of :func:`shia_v1` suitable for unit
+testing.  The function implements a very small water–balance model where
+rainfall is added to a set of conceptual stores and any overflow is routed
+directly to the outlet.  The goal is to provide a lightweight reference
+implementation while the full Fortran model is ported.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Tuple, Any
+from typing import Any, Dict, Tuple
 
 try:  # NumPy is optional for stubs
     import numpy as np
@@ -35,9 +40,15 @@ class ModelParams:
 
 @dataclass
 class ModelState:
-    storage_capilar: float
-    storage_gravita: float
-    storage_aquifer: float
+    """Container for the model state.
+
+    The three storages are expressed in millimetres and are two
+    dimensional arrays with shape ``(ny, nx)``.
+    """
+
+    storage_capilar: np.ndarray
+    storage_gravita: np.ndarray
+    storage_aquifer: np.ndarray
 
 
 def shia_v1(
@@ -47,23 +58,91 @@ def shia_v1(
     state: ModelState,
     nsteps: int,
 ) -> Tuple[ModelState, Dict[str, np.ndarray]]:
-    """Stub for the shia_v1 model.
+    """Very small water–balance model.
 
     Parameters
     ----------
-    forcings, grid: Dict[str, np.ndarray]
-        Placeholder inputs for meteorological forcings and grid data.
-    params: ModelParams
-        Model parameter container.
-    state: ModelState
-        Initial model state.
-    nsteps: int
-        Number of timesteps to integrate.
+    forcings : Dict[str, ndarray]
+        ``rain_mm_h`` – rainfall rate in millimetres per hour with shape
+        ``(nsteps, ny, nx)``.  Optionally ``et_mm_h`` or ``et_mm_d`` for
+        evapotranspiration.  Time steps are converted internally using
+        ``dt`` from ``params``.
+    grid : Dict[str, ndarray]
+        Placeholder grid information; only used for area aggregation.
+    params : ModelParams
+        Container with model parameters.  The maximum storage capacities
+        are expressed in millimetres.
+    state : ModelState
+        Initial state of the three storages in millimetres.
+    nsteps : int
+        Number of time steps to integrate.
 
     Returns
     -------
-    Tuple[ModelState, Dict[str, np.ndarray]]
-        The updated state and an empty dictionary with diagnostic arrays.
+    ModelState
+        Updated model state after ``nsteps``.
+    Dict[str, ndarray]
+        Diagnostics with two keys:
+
+        ``q_cauce_t`` – array with the same shape as ``rain_mm_h``
+            representing the (yet to be implemented) discharge in each
+            cell.  For now it is filled with zeros.
+        ``q_outlet`` – one–dimensional array of length ``nsteps`` with the
+            total surface excess (in mm) leaving the domain each step.
+
+    Notes
+    -----
+    * Rainfall is converted from mm/h to mm per step using
+      ``rain_step = rain_mm_h * (dt / 3600)``.
+    * Evapotranspiration is handled similarly, accepting both hourly and
+      daily rates.
+    * Storages are clipped to ``[0, max_*]`` at every step.
     """
-    diagnostics: Dict[str, np.ndarray] = {}
-    return state, diagnostics
+
+    rain = forcings.get("rain_mm_h")
+    if rain is None:
+        raise KeyError("forcings must contain 'rain_mm_h'")
+
+    dt = params.dt
+    ny, nx = rain.shape[1:]
+
+    q_outlet = np.zeros(nsteps, dtype=float)
+    q_cauce_t = np.zeros_like(rain)
+
+    storage_cap = state.storage_capilar.copy()
+    storage_grav = state.storage_gravita.copy()
+    storage_aqu = state.storage_aquifer.copy()
+
+    for t in range(nsteps):
+        rain_step = rain[t] * (dt / 3600.0)
+
+        et_step = np.zeros((ny, nx), dtype=float)
+        if "et_mm_h" in forcings:
+            et_step = forcings["et_mm_h"][t] * (dt / 3600.0)
+        elif "et_mm_d" in forcings:
+            et_step = forcings["et_mm_d"][t] * (dt / 86400.0)
+
+        storage_cap += rain_step
+        storage_cap -= et_step
+        storage_cap = np.clip(storage_cap, 0.0, params.max_capilar)
+        cap_excess = storage_cap - params.max_capilar
+        cap_excess[cap_excess < 0] = 0.0
+
+        storage_grav += cap_excess
+        storage_grav = np.clip(storage_grav, 0.0, params.max_gravita)
+        grav_excess = storage_grav - params.max_gravita
+        grav_excess[grav_excess < 0] = 0.0
+
+        storage_aqu += grav_excess
+        storage_aqu = np.clip(storage_aqu, 0.0, params.max_aquifer)
+        aqu_excess = storage_aqu - params.max_aquifer
+        aqu_excess[aqu_excess < 0] = 0.0
+
+        q_outlet[t] = np.sum(aqu_excess)
+
+    new_state = ModelState(storage_cap, storage_grav, storage_aqu)
+    diagnostics: Dict[str, np.ndarray] = {
+        "q_cauce_t": q_cauce_t,
+        "q_outlet": q_outlet,
+    }
+    return new_state, diagnostics

--- a/wmf_py/tests/test_cu_basics.py
+++ b/wmf_py/tests/test_cu_basics.py
@@ -1,11 +1,15 @@
-import pytest
+import numpy as np
 
-np = pytest.importorskip("numpy")
-
-from wmf_py.cu_py import basics
+from wmf_py.cu_py.basics import basin_find, basin_map2basin
 
 
-def test_dir_reclass_identity():
-    arr = np.arange(4).reshape(2, 2)
-    out = basics.dir_reclass_opentopo(arr)
-    assert np.array_equal(out, arr)
+def test_basin_find_bounds() -> None:
+    rc = basin_find(x=60, y=60, xll=0, yll=0, dx=30, dy=30, ncols=3, nrows=3)
+    assert rc == (2, 2)
+
+
+def test_basin_map2basin_mask() -> None:
+    v = np.arange(9).reshape(3, 3)
+    m = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=bool)
+    out = basin_map2basin(v, m)
+    assert np.isfinite(out[m]).all()

--- a/wmf_py/tests/test_models_core.py
+++ b/wmf_py/tests/test_models_core.py
@@ -1,27 +1,42 @@
-import pytest
-
-np = pytest.importorskip("numpy")
+import numpy as np
 
 from wmf_py.models_py.core import ModelParams, ModelState, shia_v1
 
 
-def test_shia_v1_stub_runs():
+def test_mass_balance_simple() -> None:
+    ny, nx, nt = 5, 5, 3
+    dt = 3600.0
+    rain = np.full((nt, ny, nx), 10.0)  # mm/h
+    forc = {"rain_mm_h": rain}
+    grid = {"dx": 30.0, "dy": 30.0}
     params = ModelParams(
-        dt=1.0,
-        h_coef=1.0,
-        h_exp=1.0,
-        v_coef=1.0,
-        v_exp=1.0,
-        max_capilar=1.0,
-        max_gravita=1.0,
-        max_aquifer=1.0,
+        dt=dt,
+        h_coef=1,
+        h_exp=1,
+        v_coef=1,
+        v_exp=1,
+        max_capilar=100,
+        max_gravita=200,
+        max_aquifer=400,
         drena=0.0,
         retorno_gr=0.0,
         storage_constant=0.0,
     )
-    state = ModelState(0.0, 0.0, 0.0)
-    forcings = {"rain": np.zeros(1)}
-    grid = {"area": np.zeros(1)}
-    new_state, diag = shia_v1(forcings, grid, params, state, 1)
-    assert isinstance(new_state, ModelState)
-    assert isinstance(diag, dict)
+    state = ModelState(np.zeros((ny, nx)), np.zeros((ny, nx)), np.zeros((ny, nx)))
+    state2, out = shia_v1(forc, grid, params, state, nsteps=nt)
+
+    assert "q_outlet" in out
+
+    rain_total = np.sum(rain * (dt / 3600.0))
+    delta_storage = (
+        np.sum(state2.storage_capilar)
+        + np.sum(state2.storage_gravita)
+        + np.sum(state2.storage_aquifer)
+        - (
+            np.sum(state.storage_capilar)
+            + np.sum(state.storage_gravita)
+            + np.sum(state.storage_aquifer)
+        )
+    )
+    mb = abs(rain_total - delta_storage - np.sum(out["q_outlet"])) / rain_total
+    assert mb <= 0.005

--- a/wmf_py/tests/test_utils_transform.py
+++ b/wmf_py/tests/test_utils_transform.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from wmf_py.utils.transform import Transform_Basin2Map
+
+
+def test_transform_basin2map_requires_idx() -> None:
+    with pytest.raises(NotImplementedError):
+        Transform_Basin2Map(np.array([1]), (1, 1), None)
+
+
+def test_transform_basin2map_basic() -> None:
+    values = np.array([1, 2, 3, 4])
+    idx = np.array([0, 4, 6, 8])  # map to a 3x3 grid
+    out = Transform_Basin2Map(values, (3, 3), idx, fill=-1)
+    assert out[0, 0] == 1
+    assert out[1, 1] == 2
+    assert out[2, 0] == 3
+    assert out[2, 2] == 4

--- a/wmf_py/utils/transform.py
+++ b/wmf_py/utils/transform.py
@@ -1,4 +1,5 @@
 """Utility transforms."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -12,10 +13,30 @@ except ModuleNotFoundError:  # pragma: no cover
 def Transform_Basin2Map(
     values_basin: np.ndarray,
     map_shape: tuple,
-    idx_basin_to_map: np.ndarray,
+    idx_basin_to_map: np.ndarray | None,
     fill: float = np.nan,
-) -> np.ndarray:  # pragma: no cover - stub
-    """Map basin values to a full raster shape."""
-    out = np.full(map_shape, fill)
-    out.flat[idx_basin_to_map] = values_basin
+) -> np.ndarray:
+    """Map basin values to a full raster.
+
+    Parameters
+    ----------
+    values_basin : ndarray
+        Values defined on basin cells.
+    map_shape : tuple
+        Shape ``(nrows, ncols)`` of the target map.
+    idx_basin_to_map : ndarray
+        Linear or ``(row, col)`` indices that locate each basin cell within
+        the target map.  The argument is mandatory; passing ``None`` raises
+        :class:`NotImplementedError` as a reminder that real indexing is
+        required for the transform to operate.
+    fill : float, optional
+        Value used to fill cells outside the basin (default ``np.nan``).
+    """
+
+    if idx_basin_to_map is None:
+        raise NotImplementedError("idx_basin_to_map must be provided")
+
+    out = np.full(map_shape, fill, dtype=values_basin.dtype)
+    out_flat = out.ravel()
+    out_flat[idx_basin_to_map] = values_basin
     return out


### PR DESCRIPTION
## Summary
- implement minimal shia_v1 water balance model with basic storages and outlet flow diagnostics
- add basic basin utilities and transform helpers
- introduce unit tests for hydrology core, basin tools, and basin-to-map transform
- adjust wmfv2 imports to use Python implementations where available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python - <<'PY'
from wmf_py.models_py.core import ModelParams, ModelState, shia_v1
import numpy as np
ny,nx,nt=5,5,3; dt=3600.0
rain=np.full((nt,ny,nx),10.0)
forc={"rain_mm_h":rain}; grid={"dx":30.0,"dy":30.0}
params=ModelParams(dt=dt,h_coef=1,h_exp=1,v_coef=1,v_exp=1,max_capilar=100,max_gravita=200,max_aquifer=400,drena=0.0,retorno_gr=0.0,storage_constant=0.0)
state=ModelState(np.zeros((ny,nx)),np.zeros((ny,nx)),np.zeros((ny,nx)))
_,out=shia_v1(forc,grid,params,state,nsteps=nt)
print('OK keys:', out.keys())
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python wmf_heavy/wmfv2.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68991167ca048325baa59262e685fd6c