### PR TITLE
Implement basin delineation and mapping utilities

### DIFF
--- a/wmf_py/tests/test_cu_basics.py
+++ b/wmf_py/tests/test_cu_basics.py
@@ -1,7 +1,14 @@
 import numpy as np
+import pytest
 import time
 
-from wmf_py.cu_py.basics import basin_find, basin_map2basin, basin_acum
+from wmf_py.cu_py.basics import (
+    basin_acum,
+    basin_cut,
+    basin_find,
+    dir_reclass_opentopo,
+    dir_reclass_rwatershed,
+)
 
 
 def test_basin_find_bounds() -> None:
@@ -9,17 +16,26 @@ def test_basin_find_bounds() -> None:
     assert rc == (2, 2)
 
 
-def test_basin_map2basin_mask() -> None:
-    v = np.arange(9).reshape(3, 3)
-    m = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=bool)
-    out = basin_map2basin(v, m)
-    assert np.isfinite(out[m]).all()
+def test_dir_reclass_opentopo() -> None:
+    src = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 1]])
+    res = dir_reclass_opentopo(src)
+    assert set(np.unique(res)) <= set(range(8))
+    assert np.array_equal(res, dir_reclass_opentopo(res))
+    with pytest.raises(ValueError):
+        dir_reclass_opentopo(np.array([[9]]))
+
+
+def test_dir_reclass_rwatershed_mapping() -> None:
+    src = np.arange(1, 9).reshape(2, 4)
+    res = dir_reclass_rwatershed(src)
+    expected = np.array([0, 7, 6, 5, 4, 3, 2, 1]).reshape(2, 4)
+    assert np.array_equal(res, expected)
 
 
 def test_basin_acum_d8() -> None:
-    flowdir = np.ones((7, 7), dtype=int)
-    flowdir[:, -1] = 7  # right column flows south
-    flowdir[-1, -1] = 0  # outlet
+    flowdir = np.zeros((7, 7), dtype=int)
+    flowdir[:, -1] = 2  # right column flows south
+    flowdir[-1, -1] = -1  # outlet has no direction
     mask = np.ones_like(flowdir, dtype=bool)
     acc = basin_acum(flowdir, mask)
     expected = np.array(
@@ -35,9 +51,40 @@ def test_basin_acum_d8() -> None:
         dtype=float,
     )
     assert np.array_equal(acc, expected)
-    # Simple performance sanity check
-    big_flow = np.ones((200, 200), dtype=int)
+    big_flow = np.zeros((200, 200), dtype=int)
     big_mask = np.ones_like(big_flow, dtype=bool)
     t0 = time.perf_counter()
     basin_acum(big_flow, big_mask)
     assert time.perf_counter() - t0 < 1.0
+
+
+def test_basin_cut_single() -> None:
+    flowdir = np.zeros((7, 7), dtype=int)
+    flowdir[:, -1] = 2
+    flowdir[-1, -1] = -1
+    mask = np.ones_like(flowdir, dtype=bool)
+    dem = np.ones_like(flowdir, dtype=float)
+    res = basin_cut(dem, (6, 6), flowdir, mask)
+    assert res["mask"].sum() == 49
+
+
+def test_basin_cut_two_catchments() -> None:
+    flowdir = np.zeros((7, 7), dtype=int)
+    flowdir[:3, :] = 6  # top half drains north
+    flowdir[3:, -1] = 2
+    flowdir[-1, -1] = -1
+    mask = np.ones_like(flowdir, dtype=bool)
+    dem = np.ones_like(flowdir, dtype=float)
+    res = basin_cut(dem, (6, 6), flowdir, mask)
+    assert res["mask"].sum() == 28
+
+
+def test_basin_cut_edge_outlet() -> None:
+    flowdir = np.full((5, 5), 2, dtype=int)
+    flowdir[4, :] = 0
+    flowdir[4, 2:] = 4
+    flowdir[4, 2] = -1
+    mask = np.ones_like(flowdir, dtype=bool)
+    dem = np.ones_like(flowdir, dtype=float)
+    res = basin_cut(dem, (4, 2), flowdir, mask)
+    assert res["mask"].sum() == 25

--- a/wmf_py/tests/test_transform.py
+++ b/wmf_py/tests/test_transform.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from wmf_py.cu_py.basics import basin_2map, basin_map2basin
+from wmf_py.utils.transform import Transform_Basin2Map
+
+
+def test_idx_basin_to_map_checkerboard() -> None:
+    mask = np.indices((5, 5)).sum(axis=0) % 2 == 0
+    idx = np.flatnonzero(mask.ravel(order="C"))
+    assert idx.size == mask.sum() == 13
+
+
+def test_basin_2map_and_map2basin() -> None:
+    map_shape = (50, 50)
+    idx = np.array([0, 10, 101, 555, 999, 1234, 2345, 3456, 4321, 4999])
+    values = np.arange(idx.size)
+    nodata = -1.0
+    raster = basin_2map(values, idx, map_shape, nodata)
+    assert raster.shape == map_shape
+    assert np.all(raster.ravel()[idx] == values)
+    assert (raster != nodata).sum() == values.size
+    back = basin_map2basin(raster, idx, (idx.size,))
+    assert np.array_equal(back, values)
+
+
+def test_transform_idempotent() -> None:
+    idx = np.array([0, 2, 4, 6])
+    values = np.array([[1, 2], [3, 4]])
+    map_shape = (3, 3)
+    nodata = -9999.0
+    m = basin_2map(values, idx, map_shape, nodata)
+    back = basin_map2basin(m, idx, values.shape)
+    assert np.array_equal(back, values)
+    # also test Transform_Basin2Map wrapper
+    out = Transform_Basin2Map(values, map_shape, idx, fill=nodata)
+    assert np.array_equal(out, m)

--- a/wmf_py/utils/transform.py
+++ b/wmf_py/utils/transform.py
@@ -36,7 +36,10 @@ def Transform_Basin2Map(
     if idx_basin_to_map is None:
         raise NotImplementedError("idx_basin_to_map must be provided")
 
-    out = np.full(map_shape, fill, dtype=values_basin.dtype)
-    out_flat = out.ravel()
-    out_flat[idx_basin_to_map] = values_basin
-    return out
+    vals = np.asarray(values_basin).ravel(order="C")
+    if vals.size != idx_basin_to_map.size:
+        raise ValueError("size of values and indices must match")
+
+    out = np.full(np.prod(map_shape), fill, dtype=vals.dtype)
+    out[idx_basin_to_map] = vals
+    return out.reshape(map_shape)


### PR DESCRIPTION
## Summary
- define internal clockwise D8 scheme and provide reclassification from OpenTopo and r.watershed conventions
- add basin_cut upstream delineation and linear-index based basin<->map mappers
- update Transform_Basin2Map and expand unit tests for reclassification, delineation, and mapping

## Testing
- `python -m pip install --upgrade pip` *(failed: Cannot connect to proxy 403)*
- `pip install numpy numba pytest` *(failed: Cannot connect to proxy 403)*
- `python -m pytest -q` *(failed: No module named pytest)*
- `python - <<'PY'\nimport numpy as np\nfrom wmf_py.cu_py.basics import dir_reclass_opentopo, basin_cut\nflow = np.zeros((7,7), dtype=int)\nmask = np.ones((7,7), dtype=bool)\ndem = np.arange(49, dtype=float).reshape(7,7)\nflow_internal = dir_reclass_opentopo(flow)\nres = basin_cut(dem, (3,3), flow_internal, mask)\nprint('mask cells:', res['mask'].sum())\nPY` *(failed: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68991743a89c8325a5f2fa2801c109a4