### PR TITLE
Implement Python hydrological core with full mass balance checks

### DIFF
--- a/wmf_heavy/wmfv2.py
+++ b/wmf_heavy/wmfv2.py
@@ -32,6 +32,7 @@ import matplotlib.ticker as mticker
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 # ======= Imports de módulos locales =======
+# Activar implementación en Python del núcleo hidrológico
 USE_PY = True
 
 if USE_PY:

--- a/wmf_py/models_py/core.py
+++ b/wmf_py/models_py/core.py
@@ -1,11 +1,13 @@
 """Core hydrological models in Python.
 
-This module provides dataclass containers for model parameters and state,
-and a minimal Python implementation of :func:`shia_v1` suitable for unit
-testing.  The function implements a very small water–balance model where
-rainfall is added to a set of conceptual stores and any overflow is routed
-directly to the outlet.  The goal is to provide a lightweight reference
-implementation while the full Fortran model is ported.
+This module defines light–weight dataclasses for model parameters and
+state variables together with a reference implementation of a simple
+hydrological balance model (:func:`shia_v1`).  The function converts
+rainfall and potential evapotranspiration into changes in three
+conceptual storages (capilar, gravita and aquifer) and keeps track of
+surface and baseflow discharges.  It is purposely compact and fully
+vectorised to serve as an easily testable stand‑in while the legacy
+Fortran code is ported.
 """
 
 from __future__ import annotations
@@ -32,6 +34,11 @@ class ModelParams:
     drena: float
     retorno_gr: float
     storage_constant: float
+    k_perc_cap_to_grav: float = 0.0
+    k_perc_grav_to_aqu: float = 0.0
+    k_baseflow: float = 0.0
+    max_infil_mm_h: float = 1.0e6
+    eta_priority: str = "capilar_first"
     separate_fluxes: bool = False
     save_vfluxes: bool = False
     save_storage: bool = False
@@ -43,12 +50,15 @@ class ModelState:
     """Container for the model state.
 
     The three storages are expressed in millimetres and are two
-    dimensional arrays with shape ``(ny, nx)``.
+    dimensional arrays with shape ``(ny, nx)``.  Optional diagnostic
+    variables keep the last computed surface and baseflow for each cell.
     """
 
     storage_capilar: np.ndarray
     storage_gravita: np.ndarray
     storage_aquifer: np.ndarray
+    q_super_last: np.ndarray | None = None
+    q_base_last: np.ndarray | None = None
 
 
 def shia_v1(
@@ -58,7 +68,7 @@ def shia_v1(
     state: ModelState,
     nsteps: int,
 ) -> Tuple[ModelState, Dict[str, np.ndarray]]:
-    """Very small water–balance model.
+    """Minimal hydrological balance model.
 
     Parameters
     ----------
@@ -82,21 +92,8 @@ def shia_v1(
     ModelState
         Updated model state after ``nsteps``.
     Dict[str, ndarray]
-        Diagnostics with two keys:
-
-        ``q_cauce_t`` – array with the same shape as ``rain_mm_h``
-            representing the (yet to be implemented) discharge in each
-            cell.  For now it is filled with zeros.
-        ``q_outlet`` – one–dimensional array of length ``nsteps`` with the
-            total surface excess (in mm) leaving the domain each step.
-
-    Notes
-    -----
-    * Rainfall is converted from mm/h to mm per step using
-      ``rain_step = rain_mm_h * (dt / 3600)``.
-    * Evapotranspiration is handled similarly, accepting both hourly and
-      daily rates.
-    * Storages are clipped to ``[0, max_*]`` at every step.
+        Diagnostics with keys depending on selected options.  At least
+        ``q_outlet`` is returned.
     """
 
     rain = forcings.get("rain_mm_h")
@@ -106,43 +103,180 @@ def shia_v1(
     dt = params.dt
     ny, nx = rain.shape[1:]
 
+    dt_h = dt / 3600.0
+    dt_d = dt / 86400.0
+
     q_outlet = np.zeros(nsteps, dtype=float)
-    q_cauce_t = np.zeros_like(rain)
+
+    q_super_t = q_base_t = q_total_t = None
+    if params.separate_fluxes:
+        q_super_t = np.zeros((nsteps, ny, nx), dtype=float)
+        q_base_t = np.zeros((nsteps, ny, nx), dtype=float)
+        q_total_t = np.zeros((nsteps, ny, nx), dtype=float)
+
+    storage_cap_t = storage_grav_t = storage_aqu_t = None
+    if params.save_storage:
+        storage_cap_t = np.zeros((nsteps, ny, nx), dtype=float)
+        storage_grav_t = np.zeros((nsteps, ny, nx), dtype=float)
+        storage_aqu_t = np.zeros((nsteps, ny, nx), dtype=float)
+
+    mass_err_step = np.zeros(nsteps, dtype=float)
+    mass_err_cum = np.zeros(nsteps, dtype=float)
 
     storage_cap = state.storage_capilar.copy()
     storage_grav = state.storage_gravita.copy()
     storage_aqu = state.storage_aquifer.copy()
 
+    q_super_last = (
+        np.zeros((ny, nx), dtype=float)
+        if state.q_super_last is None
+        else state.q_super_last.copy()
+    )
+    q_base_last = (
+        np.zeros((ny, nx), dtype=float)
+        if state.q_base_last is None
+        else state.q_base_last.copy()
+    )
+
+    prev_storage_sum = np.sum(storage_cap + storage_grav + storage_aqu)
+    cum_p = 0.0
+    cum_err = 0.0
+
     for t in range(nsteps):
-        rain_step = rain[t] * (dt / 3600.0)
+        rain_step = np.maximum(rain[t], 0.0) * dt_h
 
         et_step = np.zeros((ny, nx), dtype=float)
         if "et_mm_h" in forcings:
-            et_step = forcings["et_mm_h"][t] * (dt / 3600.0)
+            et_step = np.maximum(forcings["et_mm_h"][t], 0.0) * dt_h
         elif "et_mm_d" in forcings:
-            et_step = forcings["et_mm_d"][t] * (dt / 86400.0)
+            et_step = np.maximum(forcings["et_mm_d"][t], 0.0) * dt_d
 
-        storage_cap += rain_step
-        storage_cap -= et_step
+        infil = np.minimum(rain_step, params.max_infil_mm_h * dt_h)
+        exceso_super = rain_step - infil
+        storage_cap += infil
+
+        # Evapotranspiration limited by storage
+        if params.eta_priority == "proportional":
+            water_avail = storage_cap + storage_grav + storage_aqu
+            frac_cap = np.zeros_like(water_avail)
+            frac_grav = np.zeros_like(water_avail)
+            frac_aqu = np.zeros_like(water_avail)
+            np.divide(storage_cap, water_avail, out=frac_cap, where=water_avail > 0)
+            np.divide(storage_grav, water_avail, out=frac_grav, where=water_avail > 0)
+            np.divide(storage_aqu, water_avail, out=frac_aqu, where=water_avail > 0)
+            ET_cap = np.minimum(et_step * frac_cap, storage_cap)
+            ET_grav = np.minimum(et_step * frac_grav, storage_grav)
+            ET_aqu = np.minimum(et_step * frac_aqu, storage_aqu)
+        else:  # capilar_first
+            ET_cap = np.minimum(et_step, storage_cap)
+            rem = et_step - ET_cap
+            ET_grav = np.minimum(rem, storage_grav)
+            rem2 = rem - ET_grav
+            ET_aqu = np.minimum(rem2, storage_aqu)
+
+        storage_cap -= ET_cap
+        storage_grav -= ET_grav
+        storage_aqu -= ET_aqu
+        ET_total = ET_cap + ET_grav + ET_aqu
+
+        perc_cg = np.minimum(
+            params.k_perc_cap_to_grav * storage_cap, storage_cap
+        )
+        storage_cap -= perc_cg
+        storage_grav += perc_cg
+
+        perc_ga = np.minimum(
+            params.k_perc_grav_to_aqu * storage_grav, storage_grav
+        )
+        retorno = params.retorno_gr * storage_grav
+        storage_grav = storage_grav - perc_ga - retorno
+        storage_aqu += perc_ga
+
+        q_base = np.minimum(params.k_baseflow * storage_aqu, storage_aqu)
+        drena = params.drena * storage_aqu
+        storage_aqu = storage_aqu - q_base + drena
+
         storage_cap = np.clip(storage_cap, 0.0, params.max_capilar)
-        cap_excess = storage_cap - params.max_capilar
-        cap_excess[cap_excess < 0] = 0.0
-
-        storage_grav += cap_excess
         storage_grav = np.clip(storage_grav, 0.0, params.max_gravita)
-        grav_excess = storage_grav - params.max_gravita
-        grav_excess[grav_excess < 0] = 0.0
-
-        storage_aqu += grav_excess
         storage_aqu = np.clip(storage_aqu, 0.0, params.max_aquifer)
-        aqu_excess = storage_aqu - params.max_aquifer
-        aqu_excess[aqu_excess < 0] = 0.0
 
-        q_outlet[t] = np.sum(aqu_excess)
+        q_super = exceso_super + retorno
+        q_total = q_super + q_base
 
-    new_state = ModelState(storage_cap, storage_grav, storage_aqu)
-    diagnostics: Dict[str, np.ndarray] = {
-        "q_cauce_t": q_cauce_t,
-        "q_outlet": q_outlet,
+        q_super_last = q_super
+        q_base_last = q_base
+
+        if params.separate_fluxes:
+            assert q_super_t is not None and q_base_t is not None and q_total_t is not None
+            q_super_t[t] = q_super
+            q_base_t[t] = q_base
+            q_total_t[t] = q_total
+        if params.save_storage:
+            assert (
+                storage_cap_t is not None
+                and storage_grav_t is not None
+                and storage_aqu_t is not None
+            )
+            storage_cap_t[t] = storage_cap
+            storage_grav_t[t] = storage_grav
+            storage_aqu_t[t] = storage_aqu
+
+        q_outlet[t] = np.sum(q_total)
+
+        new_storage_sum = np.sum(storage_cap + storage_grav + storage_aqu)
+        deltaS = new_storage_sum - prev_storage_sum
+        prev_storage_sum = new_storage_sum
+
+        P = np.sum(rain_step)
+        ETsum = np.sum(ET_total)
+        Qsuper = np.sum(q_super)
+        Qbase = np.sum(q_base)
+        err = P - (deltaS + Qsuper + Qbase + ETsum)
+        cum_p += P
+        cum_err += err
+        rel_step = abs(err) / P if P > 0 else 0.0
+        rel_cum = abs(cum_err) / cum_p if cum_p > 0 else 0.0
+        mass_err_step[t] = rel_step
+        mass_err_cum[t] = rel_cum
+        if rel_cum > 0.01:
+            raise RuntimeError("cumulative mass balance error >1%")
+        if params.verbose and ((t + 1) % max(1, nsteps // 10) == 0):
+            total_q = Qsuper + Qbase
+            print(
+                f"step {t + 1}: P={P:.3f} ET={ETsum:.3f} Q={total_q:.3f} "
+                f"dS={deltaS:.3f} err={rel_step:.3%}"
+            )
+
+    new_state = ModelState(storage_cap, storage_grav, storage_aqu, q_super_last, q_base_last)
+
+    diagnostics: Dict[str, np.ndarray] = {"q_outlet": q_outlet}
+    if params.separate_fluxes:
+        assert q_super_t is not None and q_base_t is not None and q_total_t is not None
+        diagnostics.update(
+            {
+                "q_super_t": q_super_t,
+                "q_base_t": q_base_t,
+                "q_total_t": q_total_t,
+            }
+        )
+    if params.save_storage:
+        assert (
+            storage_cap_t is not None
+            and storage_grav_t is not None
+            and storage_aqu_t is not None
+        )
+        diagnostics.update(
+            {
+                "storage_capilar_t": storage_cap_t,
+                "storage_gravita_t": storage_grav_t,
+                "storage_aquifer_t": storage_aqu_t,
+            }
+        )
+
+    diagnostics["diag"] = {
+        "mass_error_step": mass_err_step,
+        "mass_error_cum": mass_err_cum,
     }
+
     return new_state, diagnostics
+

--- a/wmf_py/tests/test_models_core.py
+++ b/wmf_py/tests/test_models_core.py
@@ -21,6 +21,15 @@ def test_mass_balance_simple() -> None:
         drena=0.0,
         retorno_gr=0.0,
         storage_constant=0.0,
+        k_perc_cap_to_grav=0.0,
+        k_perc_grav_to_aqu=0.0,
+        k_baseflow=0.0,
+        max_infil_mm_h=1.0e6,
+        eta_priority="capilar_first",
+        separate_fluxes=False,
+        save_vfluxes=False,
+        save_storage=False,
+        verbose=False,
     )
     state = ModelState(np.zeros((ny, nx)), np.zeros((ny, nx)), np.zeros((ny, nx)))
     state2, out = shia_v1(forc, grid, params, state, nsteps=nt)
@@ -40,3 +49,106 @@ def test_mass_balance_simple() -> None:
     )
     mb = abs(rain_total - delta_storage - np.sum(out["q_outlet"])) / rain_total
     assert mb <= 0.005
+
+
+def test_baseflow_activation() -> None:
+    dt = 3600.0
+    rain = np.array([[[10.0]], [[0.0]]])  # mm/h
+    forc = {"rain_mm_h": rain}
+    params = ModelParams(
+        dt=dt,
+        h_coef=1,
+        h_exp=1,
+        v_coef=1,
+        v_exp=1,
+        max_capilar=100,
+        max_gravita=100,
+        max_aquifer=500,
+        drena=0.0,
+        retorno_gr=0.0,
+        storage_constant=0.0,
+        k_perc_cap_to_grav=1.0,
+        k_perc_grav_to_aqu=1.0,
+        k_baseflow=0.2,
+        max_infil_mm_h=100.0,
+        eta_priority="capilar_first",
+        separate_fluxes=True,
+        save_vfluxes=False,
+        save_storage=False,
+        verbose=False,
+    )
+    state = ModelState(np.zeros((1, 1)), np.zeros((1, 1)), np.zeros((1, 1)))
+    state2, out = shia_v1(forc, {}, params, state, nsteps=2)
+
+    qb = out["q_base_t"][:, 0, 0]
+    assert np.isclose(qb[0], 2.0)
+    assert np.isclose(qb[1], 1.6)
+
+
+def test_eta_priority_capilar_first() -> None:
+    dt = 3600.0
+    rain = np.zeros((1, 1, 1))
+    et = np.array([[[60.0]]])  # mm/h -> 60 mm/step
+    forc = {"rain_mm_h": rain, "et_mm_h": et}
+    params = ModelParams(
+        dt=dt,
+        h_coef=1,
+        h_exp=1,
+        v_coef=1,
+        v_exp=1,
+        max_capilar=200,
+        max_gravita=200,
+        max_aquifer=200,
+        drena=0.0,
+        retorno_gr=0.0,
+        storage_constant=0.0,
+        k_perc_cap_to_grav=0.0,
+        k_perc_grav_to_aqu=0.0,
+        k_baseflow=0.0,
+        max_infil_mm_h=100.0,
+        eta_priority="capilar_first",
+        separate_fluxes=False,
+        save_vfluxes=False,
+        save_storage=False,
+        verbose=False,
+    )
+    state = ModelState(np.array([[50.0]]), np.array([[20.0]]), np.array([[10.0]]))
+    state2, _ = shia_v1(forc, {}, params, state, nsteps=1)
+    assert np.isclose(state2.storage_capilar[0, 0], 0.0)
+    assert np.isclose(state2.storage_gravita[0, 0], 10.0)
+    assert np.isclose(state2.storage_aquifer[0, 0], 10.0)
+
+
+def test_fluxes_and_shapes() -> None:
+    dt = 3600.0
+    rain = np.array([[[50.0]]])  # mm/h
+    forc = {"rain_mm_h": rain}
+    params = ModelParams(
+        dt=dt,
+        h_coef=1,
+        h_exp=1,
+        v_coef=1,
+        v_exp=1,
+        max_capilar=100,
+        max_gravita=100,
+        max_aquifer=100,
+        drena=0.0,
+        retorno_gr=0.0,
+        storage_constant=0.0,
+        k_perc_cap_to_grav=0.0,
+        k_perc_grav_to_aqu=0.0,
+        k_baseflow=0.0,
+        max_infil_mm_h=10.0,
+        eta_priority="capilar_first",
+        separate_fluxes=True,
+        save_vfluxes=False,
+        save_storage=True,
+        verbose=False,
+    )
+    state = ModelState(np.zeros((1, 1)), np.zeros((1, 1)), np.zeros((1, 1)))
+    state2, out = shia_v1(forc, {}, params, state, nsteps=1)
+
+    assert out["q_super_t"].shape == (1, 1, 1)
+    assert out["storage_capilar_t"].shape == (1, 1, 1)
+    assert np.isclose(out["q_super_t"][0, 0, 0], 40.0)
+    assert np.isclose(out["q_outlet"][0], 40.0)


### PR DESCRIPTION
## Summary
- Expand ModelParams and ModelState for percolation, baseflow and diagnostics
- Implement vectorised shia_v1 with ETA prioritisation, percolation between storages, baseflow and mass-balance tracking
- Enable Python core in `wmfv2.py` and add unit tests for mass balance, baseflow and flux outputs

## Testing
- `pytest wmf_py/tests/test_models_core.py::test_mass_balance_simple -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68991af8c21083258fdaf55d3b569023