### PR TITLE
Implement stream and sub-basin utilities

### DIFF
--- a/wmf_py/cu_py/metrics.py
+++ b/wmf_py/cu_py/metrics.py
@@ -1,7 +1,10 @@
 """Basin metrics utilities."""
 from __future__ import annotations
 
-from typing import Dict, Any
+from collections import deque
+from typing import Any, Dict, List, Tuple
+
+from .basics import _D8
 
 try:
     import numpy as np
@@ -27,3 +30,131 @@ def basin_time_to_out(flowdir: np.ndarray, dx: float, dy: float, slope: np.ndarr
 
 def geo_hand(dem: np.ndarray, stream: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
     return dem - dem.min()
+
+
+# ---------------------------------------------------------------------------
+# Sub-basin utilities
+# ---------------------------------------------------------------------------
+
+def basin_subbasin_find(
+    stream: np.ndarray,
+    nodes: Dict[int, Tuple[int, int]],
+    edges: List[Dict[str, Any]],
+    flowdir: np.ndarray,
+    outlet_rc: Tuple[int, int],
+) -> np.ndarray:
+    """Assign sub-basin identifiers to all cells in the basin.
+
+    The algorithm labels each cell with the identifier of the first downstream
+    segment (edge) encountered along its D8 flow path.  Edge identifiers are
+    taken from the ``edges`` list which is assumed to contain an ``id`` entry.
+    Cells outside the basin or without a path to the outlet retain the value
+    zero.
+    """
+
+    ny, nx = stream.shape
+    submap = np.zeros((ny, nx), dtype=int)
+
+    # Mark stream cells that belong to each edge (excluding the downstream
+    # node which is shared with the next edge).
+    for edge in edges:
+        eid = int(edge.get("id"))
+        for r, c in edge.get("cells", [])[:-1]:
+            submap[r, c] = eid
+
+    # Propagate the identifiers upstream for all remaining cells.
+    for r in range(ny):
+        for c in range(nx):
+            if submap[r, c] != 0:
+                continue
+            path = []
+            rr, cc = r, c
+            eid = 0
+            while True:
+                path.append((rr, cc))
+                if submap[rr, cc] > 0:
+                    eid = submap[rr, cc]
+                    break
+                off = _D8.get(int(flowdir[rr, cc]))
+                if not off:
+                    break
+                rr += off[0]
+                cc += off[1]
+                if not (0 <= rr < ny and 0 <= cc < nx):
+                    eid = 0
+                    break
+            for pr, pc in path:
+                submap[pr, pc] = eid
+
+    return submap
+
+
+def basin_subbasin_cut(subbasin_map: np.ndarray, sid: int) -> np.ndarray:
+    """Return the mask corresponding to sub-basin ``sid``."""
+
+    return (subbasin_map == sid).astype(np.uint8)
+
+
+def basin_subbasin_map2subbasin(
+    values_map: np.ndarray, subbasin_map: np.ndarray
+) -> Dict[int, float]:
+    """Aggregate map values per sub-basin using a simple sum."""
+
+    out: Dict[int, float] = {}
+    ids = np.unique(subbasin_map)
+    for sid in ids:
+        if sid == 0:
+            continue
+        out[int(sid)] = float(values_map[subbasin_map == sid].sum())
+    return out
+
+
+def basin_subbasin_nod(
+    subbasin_map: np.ndarray, nodes: Dict[int, Tuple[int, int]], edges: List[Dict[str, Any]]
+) -> Dict[int, int]:
+    """Map sub-basin identifiers to their downstream node."""
+
+    nodemap: Dict[int, int] = {}
+    for edge in edges:
+        nodemap[int(edge["id"])] = int(edge["node_v"])
+    return nodemap
+
+
+def basin_subbasin_horton(
+    stream: np.ndarray, nodes: Dict[int, Tuple[int, int]], edges: List[Dict[str, Any]]
+) -> Dict[str, Dict[int, int]]:
+    """Compute Strahler (Horton) orders for the network."""
+
+    edges_by_id = {int(e["id"]): e for e in edges}
+    incoming: Dict[int, List[int]] = {nid: [] for nid in nodes}
+    outgoing: Dict[int, List[int]] = {nid: [] for nid in nodes}
+    for e in edges:
+        eid = int(e["id"])
+        u = int(e["node_u"])
+        v = int(e["node_v"])
+        outgoing[u].append(eid)
+        incoming[v].append(eid)
+
+    order_edge: Dict[int, int] = {}
+    order_node: Dict[int, int] = {}
+    upstream_orders: Dict[int, List[int]] = {nid: [] for nid in nodes}
+
+    q: deque[int] = deque(n for n, inc in incoming.items() if len(inc) == 0)
+    for n in q:
+        order_node[n] = 1
+
+    while q:
+        n = q.popleft()
+        for eid in outgoing.get(n, []):
+            order_edge[eid] = order_node[n]
+            v = edges_by_id[eid]["node_v"]
+            upstream_orders[v].append(order_edge[eid])
+            incoming[v].remove(eid)
+            if not incoming[v]:
+                vals = upstream_orders[v]
+                maxo = max(vals)
+                order_node[v] = maxo + 1 if vals.count(maxo) >= 2 else maxo
+                q.append(v)
+
+    return {"nodes": order_node, "edges": order_edge}
+

--- a/wmf_py/cu_py/streams.py
+++ b/wmf_py/cu_py/streams.py
@@ -1,54 +1,203 @@
 """Stream network utilities."""
 from __future__ import annotations
 
-from typing import Tuple, Any
+from collections import deque
+from typing import Any, Dict, List, Tuple
 
-try:
+from .basics import _D8
+
+try:  # NumPy is optional for documentation builds
     import numpy as np
-except ModuleNotFoundError:  # pragma: no cover
+except ModuleNotFoundError:  # pragma: no cover - used only when NumPy is missing
     np = Any  # type: ignore
 
 
-def stream_find(acum: np.ndarray, threshold: int) -> np.ndarray:  # pragma: no cover - stub
-    """Identify stream cells based on accumulation threshold."""
-    return (acum > threshold).astype(int)
+# ---------------------------------------------------------------------------
+# Basic stream operations
+# ---------------------------------------------------------------------------
+
+def stream_find(acum: np.ndarray, threshold: int) -> np.ndarray:
+    """Binarise a stream network from an accumulation grid.
+
+    Parameters
+    ----------
+    acum : ndarray of int
+        D8 accumulation map.
+    threshold : int
+        Minimum accumulation value for a cell to be considered part of the
+        stream network.
+
+    Returns
+    -------
+    ndarray of uint8
+        Boolean mask of the detected stream network.
+    """
+
+    return (acum >= threshold).astype(np.uint8)
 
 
-def stream_cut(stream: np.ndarray, mask_basin: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Mask the stream network within a basin."""
-    return stream * mask_basin
+def stream_cut(stream: np.ndarray, mask_basin: np.ndarray) -> np.ndarray:
+    """Restrict a stream network to a basin mask."""
+
+    return (stream.astype(np.uint8) & mask_basin.astype(np.uint8)).astype(np.uint8)
 
 
-def stream_find_to_corr(stream: np.ndarray, flowdir: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    """Find stream cells to correct."""
-    return stream
+def stream_find_to_corr(
+    stream: np.ndarray, flowdir: np.ndarray, outlet_rc: Tuple[int, int]
+) -> np.ndarray:
+    """Remove disconnected stream segments.
+
+    Starting from ``outlet_rc`` the network is explored upstream following the
+    inverse of the D8 directions.  Only cells connected to the outlet are
+    preserved; all others are set to zero.
+    """
+
+    ny, nx = stream.shape
+    r0, c0 = outlet_rc
+    out = np.zeros_like(stream, dtype=np.uint8)
+
+    if not (0 <= r0 < ny and 0 <= c0 < nx):
+        raise ValueError("outlet outside grid")
+
+    q: deque[Tuple[int, int]] = deque()
+    visited = np.zeros_like(stream, dtype=bool)
+
+    q.append((r0, c0))
+    visited[r0, c0] = True
+
+    while q:
+        r, c = q.popleft()
+        if stream[r, c]:
+            out[r, c] = 1
+        for dr, dc in _D8.values():
+            rr, cc = r + dr, c + dc
+            if not (0 <= rr < ny and 0 <= cc < nx):
+                continue
+            if visited[rr, cc] or stream[rr, cc] == 0:
+                continue
+            off = _D8.get(int(flowdir[rr, cc]))
+            if off and rr + off[0] == r and cc + off[1] == c:
+                visited[rr, cc] = True
+                q.append((rr, cc))
+
+    return out
 
 
-def basin_netxy_find(flowdir: np.ndarray, stream: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover - stub
-    """Return placeholder arrays representing network coordinates."""
-    idx = np.argwhere(stream > 0)
-    return idx[:, 0], idx[:, 1]
+# ---------------------------------------------------------------------------
+# Network nodes and segmentation
+# ---------------------------------------------------------------------------
+
+def basin_netxy_find(
+    stream: np.ndarray, flowdir: np.ndarray, outlet_rc: Tuple[int, int]
+) -> Tuple[np.ndarray, np.ndarray, Dict[int, Tuple[int, int]]]:
+    """Detect network nodes.
+
+    Parameters
+    ----------
+    stream : ndarray of bool or int
+        Stream network mask.
+    flowdir : ndarray of int
+        D8 flow direction codes using the internal convention.
+    outlet_rc : tuple of int
+        Row/column indices of the basin outlet which is always included as a
+        node.
+
+    Returns
+    -------
+    rows, cols, nodes : tuple
+        ``rows`` and ``cols`` contain the coordinates of all stream cells.
+        ``nodes`` is a dictionary ``{id: (row, col)}`` with the detected
+        network nodes.
+    """
+
+    ny, nx = stream.shape
+    rows, cols = np.nonzero(stream)
+    nodes: Dict[int, Tuple[int, int]] = {}
+    node_map = np.zeros_like(stream, dtype=int)
+    node_id = 1
+
+    for r, c in zip(rows, cols):
+        indeg = 0
+        for dr, dc in _D8.values():
+            rr, cc = r + dr, c + dc
+            if 0 <= rr < ny and 0 <= cc < nx and stream[rr, cc]:
+                off = _D8.get(int(flowdir[rr, cc]))
+                if off and rr + off[0] == r and cc + off[1] == c:
+                    indeg += 1
+
+        off = _D8.get(int(flowdir[r, c]))
+        outdeg = 0
+        if off:
+            rr, cc = r + off[0], c + off[1]
+            if 0 <= rr < ny and 0 <= cc < nx and stream[rr, cc]:
+                outdeg = 1
+
+        deg = indeg + outdeg
+        if (r, c) == outlet_rc or deg != 2:
+            node_map[r, c] = node_id
+            nodes[node_id] = (r, c)
+            node_id += 1
+
+    return rows, cols, nodes
 
 
-def basin_netxy_cut(*args, **kwargs):  # pragma: no cover - stub
-    pass
+def basin_netxy_cut(
+    stream: np.ndarray, nodes: Dict[int, Tuple[int, int]], flowdir: np.ndarray
+) -> List[Dict[str, Any]]:
+    """Segment the stream network between nodes.
+
+    Returns a list of edges where each edge is a dictionary with the keys
+    ``id``, ``node_u`` (upstream node), ``node_v`` (downstream node),
+    ``length`` (number of cells) and ``cells`` (list of ``(r, c)`` tuples).
+    """
+
+    ny, nx = stream.shape
+    node_map = np.zeros_like(stream, dtype=int)
+    for nid, (r, c) in nodes.items():
+        node_map[r, c] = nid
+
+    edges: List[Dict[str, Any]] = []
+    edge_id = 1
+
+    for nid, (r, c) in nodes.items():
+        off = _D8.get(int(flowdir[r, c]))
+        if not off:
+            continue
+        rr, cc = r + off[0], c + off[1]
+        if not (0 <= rr < ny and 0 <= cc < nx) or not stream[rr, cc]:
+            continue
+
+        path = [(r, c)]
+        while True:
+            path.append((rr, cc))
+            if node_map[rr, cc] and node_map[rr, cc] != nid:
+                edges.append(
+                    {
+                        "id": edge_id,
+                        "node_u": nid,
+                        "node_v": node_map[rr, cc],
+                        "length": len(path),
+                        "cells": path.copy(),
+                    }
+                )
+                edge_id += 1
+                break
+
+            off = _D8.get(int(flowdir[rr, cc]))
+            if not off:
+                break
+            rr += off[0]
+            cc += off[1]
+
+    return edges
 
 
-def basin_subbasin_find(*args, **kwargs):  # pragma: no cover - stub
-    pass
+# Re-export sub-basin utilities from :mod:`metrics` to keep compatibility
+from .metrics import (  # noqa: E402  (imported late to avoid circular refs)
+    basin_subbasin_cut,
+    basin_subbasin_find,
+    basin_subbasin_horton,
+    basin_subbasin_map2subbasin,
+    basin_subbasin_nod,
+)
 
-
-def basin_subbasin_cut(*args, **kwargs):  # pragma: no cover - stub
-    pass
-
-
-def basin_subbasin_map2subbasin(*args, **kwargs):  # pragma: no cover - stub
-    pass
-
-
-def basin_subbasin_nod(*args, **kwargs):  # pragma: no cover - stub
-    pass
-
-
-def basin_subbasin_horton(*args, **kwargs):  # pragma: no cover - stub
-    pass

--- a/wmf_py/tests/test_streams.py
+++ b/wmf_py/tests/test_streams.py
@@ -1,0 +1,69 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from wmf_py.cu_py import streams
+
+
+def _y_network():
+    """Return a simple Y-shaped network for testing."""
+    stream = np.zeros((5, 5), dtype=np.uint8)
+    stream[:, 2] = 1  # main stem
+    stream[2, 0] = 1
+    stream[2, 1] = 1
+
+    flowdir = np.full((5, 5), -1, dtype=int)
+    for r in range(4):
+        flowdir[r, 2] = 2  # south
+    flowdir[4, 2] = 4  # west (outlet)
+    flowdir[2, 0] = 0  # east
+    flowdir[2, 1] = 0  # east
+
+    outlet = (4, 2)
+    return stream, flowdir, outlet
+
+
+def test_stream_find_threshold():
+    acum = np.array(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 2, 3, 4, 0],
+            [0, 3, 4, 5, 0],
+            [0, 4, 5, 6, 0],
+            [0, 0, 0, 0, 0],
+        ]
+    )
+    counts = []
+    for thr in (2, 3, 5):
+        counts.append(streams.stream_find(acum, thr).sum())
+    assert counts[0] >= counts[1] >= counts[2]
+
+
+def test_stream_find_to_corr_removes_island():
+    stream, flowdir, outlet = _y_network()
+    stream[0, 4] = 1
+    stream[1, 4] = 1
+    flowdir[0, 4] = 2
+    flowdir[1, 4] = 2
+
+    corrected = streams.stream_find_to_corr(stream, flowdir, outlet)
+    assert corrected[0, 4] == 0 and corrected[1, 4] == 0
+
+
+def test_basin_netxy_find_cut():
+    stream, flowdir, outlet = _y_network()
+    _, _, nodes = streams.basin_netxy_find(stream, flowdir, outlet)
+    edges = streams.basin_netxy_cut(stream, nodes, flowdir)
+    assert len(nodes) == 4
+    assert len(edges) == 3
+
+
+def test_basin_netxy_remove_tributary():
+    stream, flowdir, outlet = _y_network()
+    stream[2, 0] = 0
+    stream[2, 1] = 0
+    _, _, nodes = streams.basin_netxy_find(stream, flowdir, outlet)
+    edges = streams.basin_netxy_cut(stream, nodes, flowdir)
+    assert len(nodes) == 2
+    assert len(edges) == 1
+

--- a/wmf_py/tests/test_subbasins.py
+++ b/wmf_py/tests/test_subbasins.py
@@ -1,0 +1,55 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from wmf_py.cu_py import streams, metrics
+
+
+def _y_network():
+    stream = np.zeros((5, 5), dtype=np.uint8)
+    stream[:, 2] = 1
+    stream[2, 0] = 1
+    stream[2, 1] = 1
+
+    flowdir = np.full((5, 5), -1, dtype=int)
+    for r in range(4):
+        flowdir[r, 2] = 2
+    flowdir[4, 2] = 4
+    flowdir[2, 0] = 0
+    flowdir[2, 1] = 0
+
+    outlet = (4, 2)
+    return stream, flowdir, outlet
+
+
+def test_subbasin_find_and_cut():
+    stream, flowdir, outlet = _y_network()
+    _, _, nodes = streams.basin_netxy_find(stream, flowdir, outlet)
+    edges = streams.basin_netxy_cut(stream, nodes, flowdir)
+    submap = metrics.basin_subbasin_find(stream, nodes, edges, flowdir, outlet)
+    ids = [e["id"] for e in edges]
+    assert set(np.unique(submap)) >= {0, *ids}
+
+    masks = [metrics.basin_subbasin_cut(submap, i) for i in ids]
+    total = np.sum(masks, axis=0)
+    assert np.all(total <= 1)
+    assert total.sum() == (submap > 0).sum()
+
+
+def test_subbasin_map_and_horton():
+    stream, flowdir, outlet = _y_network()
+    _, _, nodes = streams.basin_netxy_find(stream, flowdir, outlet)
+    edges = streams.basin_netxy_cut(stream, nodes, flowdir)
+    submap = metrics.basin_subbasin_find(stream, nodes, edges, flowdir, outlet)
+
+    vals = np.ones_like(submap, dtype=float)
+    areas = metrics.basin_subbasin_map2subbasin(vals, submap)
+    assert sum(areas.values()) == (submap > 0).sum()
+
+    nodemap = metrics.basin_subbasin_nod(submap, nodes, edges)
+    assert set(nodemap.keys()) == {e["id"] for e in edges}
+
+    horton = metrics.basin_subbasin_horton(stream, nodes, edges)
+    edge_orders = horton["edges"].values()
+    assert list(sorted(edge_orders)) == [1, 1, 2]
+


### PR DESCRIPTION
## Summary
- Add stream network detection, clipping, and connectivity correction helpers
- Detect network nodes and segment streams into edges
- Provide sub-basin mapping, aggregation, node linkage and Strahler order utilities
- Introduce synthetic tests for stream and sub-basin behaviour

## Testing
- `pytest -q wmf_py/tests/test_streams.py` *(skipped: missing numpy)*
- `pytest -q wmf_py/tests/test_subbasins.py` *(skipped: missing numpy)*
- `pip install numpy` *(failed: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6899209e243c8325a20bfe56eedf3ef4