### PR TITLE
Implement hypsometric curve, travel time, and HAND metrics

### DIFF
--- a/wmf_py/cu_py/metrics.py
+++ b/wmf_py/cu_py/metrics.py
@@ -12,6 +12,255 @@ except ModuleNotFoundError:  # pragma: no cover
     np = Any  # type: ignore
 
 
+def hypsometric_points(dem: np.ndarray, mask_basin: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return sorted elevations and cumulative area fraction for a basin.
+
+    Parameters
+    ----------
+    dem : ndarray of float
+        Digital elevation model in metres.
+    mask_basin : ndarray of bool
+        Mask delineating the basin. ``True`` denotes active cells.
+
+    Returns
+    -------
+    tuple of ndarray
+        ``(elev_sorted, area_cum_frac)`` where ``elev_sorted`` contains the
+        basin elevations in ascending order and ``area_cum_frac`` the
+        corresponding cumulative area fraction in the range ``0..1``.
+    """
+
+    dem_vals = dem[mask_basin]
+    dem_vals = dem_vals[~np.isnan(dem_vals)]
+    if dem_vals.size == 0:
+        return np.array([]), np.array([])
+
+    elev_sorted = np.sort(dem_vals)
+    n = elev_sorted.size
+    area_cum_frac = np.arange(1, n + 1, dtype=float) / float(n)
+    return elev_sorted, area_cum_frac
+
+
+def hypsometric_curve(dem: np.ndarray, mask_basin: np.ndarray, nbins: int = 100) -> dict:
+    """Compute a binned hypsometric curve for the basin.
+
+    Parameters
+    ----------
+    dem : ndarray
+        Digital elevation model in metres.
+    mask_basin : ndarray of bool
+        Basin mask where ``True`` denotes active cells.
+    nbins : int, optional
+        Number of bins/percentiles for the curve, by default ``100``.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``elev_bins`` (elevation percentiles),
+        ``area_frac`` (area fraction), ``min`` and ``max`` elevations and the
+        mean elevation (``mean_elev``).
+    """
+
+    dem_vals = dem[mask_basin]
+    dem_vals = dem_vals[~np.isnan(dem_vals)]
+    if dem_vals.size == 0:
+        empty = np.array([])
+        return {
+            "elev_bins": empty,
+            "area_frac": empty,
+            "min": float("nan"),
+            "max": float("nan"),
+            "mean_elev": float("nan"),
+        }
+
+    elev_bins = np.percentile(dem_vals, np.linspace(0, 100, nbins))
+    area_frac = np.linspace(0.0, 1.0, nbins)
+    return {
+        "elev_bins": elev_bins,
+        "area_frac": area_frac,
+        "min": float(dem_vals.min()),
+        "max": float(dem_vals.max()),
+        "mean_elev": float(dem_vals.mean()),
+    }
+
+
+def travel_velocity_manning(slope_cell: float, n: float, R: float) -> float:
+    """Compute flow velocity using Manning's equation.
+
+    Parameters
+    ----------
+    slope_cell : float
+        Slope (``m/m``).  Values are expected to be non-negative.
+    n : float
+        Manning roughness coefficient.
+    R : float
+        Hydraulic radius (approximated by water depth) in metres.
+
+    Returns
+    -------
+    float
+        Velocity in ``m/s``.
+    """
+
+    return (1.0 / n) * (R ** (2.0 / 3.0)) * (slope_cell ** 0.5)
+
+
+def time_to_outlet(
+    flowdir: np.ndarray,
+    slope: np.ndarray | None,
+    mask_basin: np.ndarray,
+    stream_mask: np.ndarray,
+    dx: float,
+    dy: float,
+    params: dict,
+    outlet_rc: tuple[int, int],
+) -> np.ndarray:
+    """Compute travel time from each cell to the basin outlet.
+
+    The computation follows D8 directions using velocities derived from
+    Manning's equation.  Times are accumulated downstream so that each cell
+    reports the total travel time to the specified ``outlet_rc``.
+    """
+
+    if slope is None:
+        raise ValueError("slope array is required")
+    if not mask_basin[outlet_rc]:
+        raise ValueError("outlet outside basin mask")
+
+    ny, nx = flowdir.shape
+    time_map = np.full((ny, nx), np.nan, dtype=float)
+
+    receivers = np.full((ny, nx, 2), -1, dtype=int)
+    indegree = np.zeros((ny, nx), dtype=int)
+
+    for r in range(ny):
+        for c in range(nx):
+            if not mask_basin[r, c]:
+                continue
+            off = _D8.get(int(flowdir[r, c]))
+            if not off:
+                continue
+            rr, cc = r + off[0], c + off[1]
+            if 0 <= rr < ny and 0 <= cc < nx and mask_basin[rr, cc]:
+                receivers[r, c] = (rr, cc)
+                indegree[rr, cc] += 1
+
+    order: list[tuple[int, int]] = []
+    q: deque[tuple[int, int]] = deque()
+    for r in range(ny):
+        for c in range(nx):
+            if mask_basin[r, c] and indegree[r, c] == 0:
+                q.append((r, c))
+    while q:
+        r, c = q.popleft()
+        order.append((r, c))
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            continue
+        indegree[rr, cc] -= 1
+        if indegree[rr, cc] == 0:
+            q.append((rr, cc))
+
+    S_min = params.get("S_min", 1e-4)
+    n_over = params.get("n_overland")
+    h_over = params.get("h_overland_m")
+    n_ch = params.get("n_channel")
+    h_ch = params.get("h_channel_m")
+
+    diag_len = float(np.hypot(dx, dy))
+
+    cell_time = np.full((ny, nx), np.nan, dtype=float)
+    for r in range(ny):
+        for c in range(nx):
+            if not mask_basin[r, c]:
+                continue
+            S = max(float(slope[r, c]), S_min)
+            if stream_mask[r, c]:
+                v = travel_velocity_manning(S, n_ch, h_ch)
+            else:
+                v = travel_velocity_manning(S, n_over, h_over)
+            code = int(flowdir[r, c])
+            off = _D8.get(code)
+            if not off:
+                L = 0.0
+            elif off[0] != 0 and off[1] != 0:
+                L = diag_len
+            elif off[0] == 0:
+                L = dx
+            else:
+                L = dy
+            cell_time[r, c] = L / v if v > 0 else np.nan
+
+    for r, c in reversed(order):
+        if not mask_basin[r, c]:
+            continue
+        if (r, c) == outlet_rc:
+            time_map[r, c] = 0.0
+            continue
+        rr, cc = receivers[r, c]
+        if rr == -1 or np.isnan(cell_time[r, c]):
+            time_map[r, c] = np.nan
+        else:
+            time_map[r, c] = cell_time[r, c] + time_map[rr, cc]
+
+    time_map[~mask_basin] = np.nan
+    return time_map
+
+
+def hand(
+    dem: np.ndarray,
+    flowdir: np.ndarray,
+    stream_mask: np.ndarray,
+    mask_basin: np.ndarray,
+) -> np.ndarray:
+    """Compute the Height Above Nearest Drainage (HAND) metric."""
+
+    ny, nx = dem.shape
+    base = np.full_like(dem, np.nan, dtype=float)
+    base[stream_mask & mask_basin] = dem[stream_mask & mask_basin]
+
+    receivers = np.full((ny, nx, 2), -1, dtype=int)
+    indegree = np.zeros((ny, nx), dtype=int)
+    for r in range(ny):
+        for c in range(nx):
+            if not mask_basin[r, c]:
+                continue
+            off = _D8.get(int(flowdir[r, c]))
+            if not off:
+                continue
+            rr, cc = r + off[0], c + off[1]
+            if 0 <= rr < ny and 0 <= cc < nx and mask_basin[rr, cc]:
+                receivers[r, c] = (rr, cc)
+                indegree[rr, cc] += 1
+
+    order: list[tuple[int, int]] = []
+    q: deque[tuple[int, int]] = deque()
+    for r in range(ny):
+        for c in range(nx):
+            if mask_basin[r, c] and indegree[r, c] == 0:
+                q.append((r, c))
+    while q:
+        r, c = q.popleft()
+        order.append((r, c))
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            continue
+        indegree[rr, cc] -= 1
+        if indegree[rr, cc] == 0:
+            q.append((rr, cc))
+
+    for r, c in reversed(order):
+        if not mask_basin[r, c] or stream_mask[r, c]:
+            continue
+        rr, cc = receivers[r, c]
+        if rr != -1:
+            base[r, c] = base[rr, cc]
+
+    out = dem.astype(float) - base
+    out[~mask_basin] = np.nan
+    out = np.maximum(out, 0.0)
+    return out
+
 def basin_ppalstream_find(*args, **kwargs):  # pragma: no cover - stub
     pass
 

--- a/wmf_py/tests/test_metrics.py
+++ b/wmf_py/tests/test_metrics.py
@@ -1,0 +1,148 @@
+import numpy as np
+from wmf_py.cu_py.metrics import (
+    hypsometric_points,
+    hypsometric_curve,
+    time_to_outlet,
+    hand,
+)
+
+# Default parameters for time_to_outlet tests
+PARAMS = {
+    "n_overland": 0.05,
+    "h_overland_m": 0.005,
+    "n_channel": 0.035,
+    "h_channel_m": 0.5,
+    "S_min": 1e-4,
+}
+
+
+def basic_flow_grid():
+    flowdir = np.array(
+        [
+            [2, 2, 2],
+            [2, 2, 2],
+            [0, 2, 4],
+        ],
+        dtype=int,
+    )
+    mask = np.ones_like(flowdir, dtype=bool)
+    stream = np.zeros_like(flowdir, dtype=bool)
+    outlet = (2, 1)
+    return flowdir, mask, stream, outlet
+
+
+def test_hypsometric_points_and_curve():
+    dem = np.arange(100, dtype=float).reshape(10, 10)
+    mask = np.ones_like(dem, dtype=bool)
+
+    elev, area = hypsometric_points(dem, mask)
+    assert np.all(np.diff(elev) >= 0)
+    assert np.all(np.diff(area) >= 0)
+    assert abs(elev[0] - dem.min()) < 1e-9
+    assert abs(elev[-1] - dem.max()) < 1e-9
+
+    curve = hypsometric_curve(dem, mask, nbins=10)
+    assert len(curve["elev_bins"]) == 10
+    assert len(curve["area_frac"]) == 10
+    assert abs(curve["elev_bins"][0] - dem.min()) < 1e-9
+    assert abs(curve["elev_bins"][-1] - dem.max()) < 1e-9
+    assert np.all(np.diff(curve["elev_bins"]) >= 0)
+    assert np.all(np.diff(curve["area_frac"]) >= 0)
+
+
+def test_time_to_outlet_slope_effect():
+    flowdir, mask, stream, outlet = basic_flow_grid()
+    slope1 = np.full_like(flowdir, 0.01, dtype=float)
+    slope2 = np.full_like(flowdir, 0.001, dtype=float)
+    t1 = time_to_outlet(flowdir, slope1, mask, stream, 30.0, 30.0, PARAMS, outlet)
+    t2 = time_to_outlet(flowdir, slope2, mask, stream, 30.0, 30.0, PARAMS, outlet)
+    assert t1[0, 0] < t2[0, 0]
+    assert t1[outlet] == 0.0
+    assert t2[outlet] == 0.0
+
+
+def test_time_to_outlet_manning_effect():
+    flowdir, mask, stream, outlet = basic_flow_grid()
+    slope = np.full_like(flowdir, 0.01, dtype=float)
+    params_fast = PARAMS.copy()
+    params_slow = PARAMS.copy()
+    params_fast["n_overland"] = 0.05
+    params_slow["n_overland"] = 0.1
+    t_fast = time_to_outlet(flowdir, slope, mask, stream, 30.0, 30.0, params_fast, outlet)
+    t_slow = time_to_outlet(flowdir, slope, mask, stream, 30.0, 30.0, params_slow, outlet)
+    assert t_fast[0, 0] < t_slow[0, 0]
+
+
+def test_time_to_outlet_channel_vs_overland():
+    flowdir = np.array(
+        [
+            [0, 0, 2],
+            [0, 0, 2],
+            [0, 0, 6],
+        ],
+        dtype=int,
+    )
+    mask = np.ones_like(flowdir, dtype=bool)
+    stream = np.zeros_like(flowdir, dtype=bool)
+    stream[1, :] = True
+    slope = np.full_like(flowdir, 0.01, dtype=float)
+    outlet = (1, 2)
+    t = time_to_outlet(flowdir, slope, mask, stream, 30.0, 30.0, PARAMS, outlet)
+    assert t[1, 0] < t[0, 1]
+
+
+def test_time_to_outlet_smin():
+    flowdir, mask, stream, outlet = basic_flow_grid()
+    slope = np.zeros_like(flowdir, dtype=float)
+    t = time_to_outlet(flowdir, slope, mask, stream, 30.0, 30.0, PARAMS, outlet)
+    assert np.isfinite(t[0, 0]) and t[0, 0] >= 0
+
+
+def test_hand_basic():
+    dem = np.array(
+        [
+            [110.0, 105.0, 100.0],
+            [110.0, 105.0, 100.0],
+            [110.0, 105.0, 100.0],
+        ]
+    )
+    flowdir = np.array(
+        [
+            [0, 0, 2],
+            [0, 0, 2],
+            [0, 0, 2],
+        ],
+        dtype=int,
+    )
+    mask = np.ones_like(flowdir, dtype=bool)
+    stream = np.zeros_like(flowdir, dtype=bool)
+    stream[:, 2] = True
+    h = hand(dem, flowdir, stream, mask)
+    assert np.allclose(h[:, 2], 0.0, atol=1e-6)
+    assert h[0, 0] > h[0, 1] > h[0, 2]
+
+
+def test_hand_two_streams_flow_path():
+    dem = np.array(
+        [
+            [5.0, 6.0, 10.0],
+            [4.0, 5.0, 6.0],
+            [0.0, 3.0, 5.0],
+        ]
+    )
+    flowdir = np.array(
+        [
+            [2, 2, 3],
+            [2, 3, 2],
+            [0, 0, 0],
+        ],
+        dtype=int,
+    )
+    mask = np.ones_like(flowdir, dtype=bool)
+    stream = np.zeros_like(flowdir, dtype=bool)
+    stream[2, 0] = True
+    stream[2, 2] = True
+    h = hand(dem, flowdir, stream, mask)
+    # Cell (0,2) flows to stream (2,0) even though (2,2) is closer
+    assert h[0, 2] == dem[0, 2] - dem[2, 0]
+    assert h[1, 2] == dem[1, 2] - dem[2, 2]


### PR DESCRIPTION
## Summary
- add hypsometric curve utilities and Manning-based travel time and HAND computations
- include comprehensive unit tests for new basin metrics

## Testing
- `pytest -q wmf_py/tests/test_metrics.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689924b2cfd883259ec84e265e9e19ca