### PR TITLE
Add IO utilities for rasters, NetCDF, and CSV

### DIFF
--- a/wmf_py/tests/test_io.py
+++ b/wmf_py/tests/test_io.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from wmf_py.utils.io import (
+    read_raster,
+    write_geotiff,
+    read_netcdf,
+    write_netcdf,
+    write_csv,
+)
+
+rasterio = pytest.importorskip("rasterio")
+netCDF4 = pytest.importorskip("netCDF4")
+
+
+def test_geotiff_roundtrip(tmp_path: Path) -> None:
+    arr = np.arange(9, dtype=np.float32).reshape(3, 3)
+    meta = {
+        "crs": "EPSG:4326",
+        "transform": rasterio.transform.from_origin(0, 3, 1, 1),
+        "nodata": -9999.0,
+        "dtype": "float32",
+    }
+    path = tmp_path / "test.tif"
+    write_geotiff(path, arr, meta)
+    out, out_meta = read_raster(path)
+    assert np.allclose(arr, out)
+    assert out_meta["crs"].to_string() == "EPSG:4326"
+
+
+def test_netcdf_roundtrip(tmp_path: Path) -> None:
+    arr = np.random.rand(2, 3, 4).astype("float32")
+    path = tmp_path / "test.nc"
+    write_netcdf(path, {"var": arr}, {"units": "m"})
+    data = read_netcdf(path, ["var"])
+    assert np.allclose(arr, data["var"])
+
+
+def test_write_csv(tmp_path: Path) -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    path = tmp_path / "out.csv"
+    write_csv(path, df)
+    loaded = pd.read_csv(path)
+    pd.testing.assert_frame_equal(df, loaded)

--- a/wmf_py/utils/__init__.py
+++ b/wmf_py/utils/__init__.py
@@ -1,0 +1,10 @@
+"""Utility subpackage."""
+
+from .io import (
+    MissingDependencyError,
+    read_raster,
+    write_geotiff,
+    read_netcdf,
+    write_netcdf,
+    write_csv,
+)

--- a/wmf_py/utils/io.py
+++ b/wmf_py/utils/io.py
@@ -1,0 +1,174 @@
+"""Utility functions for raster/NetCDF/CSV IO."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import rasterio
+except Exception:  # pragma: no cover - import-time failure
+    rasterio = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from netCDF4 import Dataset
+except Exception:  # pragma: no cover - import-time failure
+    Dataset = None  # type: ignore
+
+Array = np.ndarray
+Meta = Mapping[str, object]
+
+
+class MissingDependencyError(RuntimeError):
+    """Raised when an optional dependency is not available."""
+
+
+# ---------------------------------------------------------------------------
+# GeoTIFF helpers
+# ---------------------------------------------------------------------------
+
+def read_raster(path: str | Path) -> Tuple[Array, Dict[str, object]]:
+    """Read a single-band raster returning the array and metadata.
+
+    Parameters
+    ----------
+    path: str or Path
+        Path to the GeoTIFF file.
+
+    Returns
+    -------
+    array: np.ndarray
+        Array with raster values.
+    meta: dict
+        Raster metadata including CRS, transform, nodata and dtype.
+    """
+    if rasterio is None:
+        raise MissingDependencyError("rasterio is required to read rasters")
+
+    with rasterio.open(path) as src:
+        array = src.read(1, masked=False)
+        meta = src.meta.copy()
+    return array, meta
+
+
+def write_geotiff(path: str | Path, array: Array, meta: Mapping[str, object]) -> None:
+    """Write a 2D array to GeoTIFF using provided metadata.
+
+    Handles ``np.ma.MaskedArray`` by filling with ``nodata``.
+    """
+    if rasterio is None:
+        raise MissingDependencyError("rasterio is required to write rasters")
+
+    data = array
+    if np.ma.isMaskedArray(array):
+        nodata = meta.get("nodata")
+        fill_value = nodata if nodata is not None else np.nan
+        data = array.filled(fill_value)
+
+    meta_out = dict(meta)
+    meta_out.update(
+        {
+            "driver": "GTiff",
+            "height": data.shape[0],
+            "width": data.shape[1],
+            "count": 1,
+            "dtype": str(data.dtype),
+        }
+    )
+
+    with rasterio.open(path, "w", **meta_out) as dst:
+        dst.write(data, 1)
+
+
+# ---------------------------------------------------------------------------
+# NetCDF helpers
+# ---------------------------------------------------------------------------
+
+def _require_netcdf() -> None:
+    if Dataset is None:
+        raise MissingDependencyError("netCDF4 is required for NetCDF operations")
+
+
+def read_netcdf(paths_or_dir: str | Path | Iterable[str | Path], varnames: Iterable[str]) -> Dict[str, Array]:
+    """Read variables from NetCDF files.
+
+    Parameters
+    ----------
+    paths_or_dir: str, Path or iterable of paths
+        Path(s) to NetCDF file(s) or directory containing them.
+    varnames: iterable of str
+        Variable names to load.
+    """
+    _require_netcdf()
+
+    if isinstance(paths_or_dir, (str, Path)) and Path(paths_or_dir).is_dir():
+        paths = [p for p in Path(paths_or_dir).glob("*.nc")]
+    elif isinstance(paths_or_dir, (str, Path)):
+        paths = [Path(paths_or_dir)]
+    else:
+        paths = [Path(p) for p in paths_or_dir]
+
+    data: Dict[str, Array] = {}
+    missing = set(varnames)
+
+    for p in paths:
+        with Dataset(p) as ds:
+            for name in list(missing):
+                if name in ds.variables:
+                    data[name] = np.asarray(ds.variables[name][:])
+                    missing.remove(name)
+        if not missing:
+            break
+
+    if missing:
+        raise ValueError(f"Variables not found in NetCDF files: {sorted(missing)}")
+
+    return data
+
+
+def write_netcdf(path: str | Path, data_dict: Mapping[str, Array], attrs_dict: Mapping[str, object] | None = None) -> None:
+    """Write a dictionary of arrays to a NetCDF file.
+
+    All arrays must share the same shape. Supported shapes are ``(y, x)`` or
+    ``(time, y, x)``.
+    """
+    _require_netcdf()
+
+    if not data_dict:
+        raise ValueError("data_dict must not be empty")
+
+    shapes = {tuple(v.shape) for v in data_dict.values()}
+    if len(shapes) != 1:
+        raise ValueError("All arrays in data_dict must have the same shape")
+    shape = next(iter(shapes))
+
+    if len(shape) == 2:
+        dims = ("y", "x")
+    elif len(shape) == 3:
+        dims = ("time", "y", "x")
+    else:
+        raise ValueError("Arrays must be 2D or 3D")
+
+    with Dataset(path, "w", format="NETCDF4") as ds:
+        for dim, size in zip(dims, shape):
+            ds.createDimension(dim, size)
+        for name, array in data_dict.items():
+            var = ds.createVariable(name, array.dtype, dims)
+            var[:] = array
+        if attrs_dict:
+            for key, val in attrs_dict.items():
+                ds.setncattr(key, val)
+
+
+# ---------------------------------------------------------------------------
+# CSV helper
+# ---------------------------------------------------------------------------
+
+def write_csv(path: str | Path, dataframe_or_records) -> None:
+    """Write a CSV file from a DataFrame or an iterable of records."""
+    if isinstance(dataframe_or_records, pd.DataFrame):
+        dataframe_or_records.to_csv(path, index=False)
+    else:
+        pd.DataFrame(dataframe_or_records).to_csv(path, index=False)


### PR DESCRIPTION
## Summary
- implement read/write helpers for GeoTIFF, NetCDF, and CSV
- expose IO utilities from utils package
- add unit tests covering round trips for each format

## Testing
- `pytest -q wmf_py/tests/test_io.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689927e622d883258061b75c343d76d2