### PR TITLE
Add stream seeding and hydrological metrics utilities

### DIFF
--- a/wmf_py/cu_py/streams.py
+++ b/wmf_py/cu_py/streams.py
@@ -84,6 +84,191 @@ def stream_find_to_corr(
 
 
 # ---------------------------------------------------------------------------
+# Stream extraction from approximate coordinates
+# ---------------------------------------------------------------------------
+
+def stream_seed_from_coords(
+    acum: np.ndarray,
+    x: float,
+    y: float,
+    xll: float,
+    yll: float,
+    dx: float,
+    dy: float,
+    outlet_rc: Tuple[int, int],
+    search_radius_cells: int = 4,
+    min_threshold: int = 1,
+) -> Dict[str, Any]:
+    """Locate a seed cell near provided map coordinates.
+
+    The function converts the ``(x, y)`` coordinates to array indices and then
+    searches within a square window of size ``(2 * R + 1)`` centred on the
+    initial location.  The cell with the largest accumulation value is chosen
+    as seed.  Ties are broken by selecting the cell with the smallest Manhattan
+    distance to the original location.  Cells with accumulation below
+    ``min_threshold`` are ignored.
+
+    Parameters
+    ----------
+    acum : ndarray of int
+        Accumulation grid.
+    x, y : float
+        Approximate coordinates of the stream in metres.
+    xll, yll : float
+        Lower-left corner of the grid in metres.
+    dx, dy : float
+        Cell resolution in ``x`` and ``y`` (metres).
+    outlet_rc : tuple of int
+        Unused but kept for API compatibility.
+    search_radius_cells : int, optional
+        Radius of the search window in cells (default ``4``).
+    min_threshold : int, optional
+        Minimum accumulation value to consider a cell (default ``1``).
+
+    Returns
+    -------
+    dict
+        ``{"seed_rc": (row, col), "acum_val": int}`` with the selected seed
+        cell and its accumulation value.
+    """
+
+    from .basics import basin_find  # local import to avoid circular
+
+    ny, nx = acum.shape
+    r0, c0 = basin_find(x, y, xll, yll, dx, dy, nx, ny)
+
+    rmin = max(r0 - search_radius_cells, 0)
+    rmax = min(r0 + search_radius_cells, ny - 1)
+    cmin = max(c0 - search_radius_cells, 0)
+    cmax = min(c0 + search_radius_cells, nx - 1)
+
+    best_rc = None
+    best_val = min_threshold - 1
+    best_dist = None
+
+    for rr in range(rmin, rmax + 1):
+        for cc in range(cmin, cmax + 1):
+            val = int(acum[rr, cc])
+            if val < min_threshold:
+                continue
+            dist = abs(rr - r0) + abs(cc - c0)
+            if (
+                val > best_val
+                or (val == best_val and (best_dist is None or dist < best_dist))
+            ):
+                best_val = val
+                best_dist = dist
+                best_rc = (rr, cc)
+
+    if best_rc is None:
+        raise ValueError("no valid seed found near provided coordinates")
+
+    return {"seed_rc": best_rc, "acum_val": int(best_val)}
+
+
+def _connects_to_outlet(
+    stream: np.ndarray,
+    flowdir: np.ndarray,
+    start: Tuple[int, int],
+    outlet: Tuple[int, int],
+) -> bool:
+    """Check if ``start`` reaches ``outlet`` following ``flowdir`` within ``stream``."""
+
+    ny, nx = stream.shape
+    r, c = start
+    visited = set()
+    while True:
+        if (r, c) == outlet:
+            return True
+        if (r, c) in visited:
+            return False
+        visited.add((r, c))
+        if not stream[r, c]:
+            return False
+        off = _D8.get(int(flowdir[r, c]))
+        if not off:
+            return False
+        r += off[0]
+        c += off[1]
+        if not (0 <= r < ny and 0 <= c < nx):
+            return False
+
+
+def stream_threshold_nearby(
+    acum: np.ndarray,
+    seed_rc: Tuple[int, int],
+    flowdir: np.ndarray,
+    outlet_rc: Tuple[int, int],
+    candidate_thresholds: List[int],
+) -> int:
+    """Select the highest accumulation threshold keeping connectivity."""
+
+    if not candidate_thresholds:
+        raise ValueError("empty candidate_thresholds")
+
+    thresholds = sorted(candidate_thresholds, reverse=True)
+    feasible_min: int | None = None
+
+    for thr in thresholds:
+        stream = acum >= thr
+        if not stream[seed_rc]:
+            continue
+        feasible_min = thr  # at least seed belongs to this threshold
+        if stream[outlet_rc] and _connects_to_outlet(stream, flowdir, seed_rc, outlet_rc):
+            return thr
+
+    if feasible_min is not None:
+        return feasible_min
+    raise ValueError("seed cell excluded for all thresholds")
+
+
+def stream_find_nearby(
+    acum: np.ndarray,
+    flowdir: np.ndarray,
+    x: float,
+    y: float,
+    xll: float,
+    yll: float,
+    dx: float,
+    dy: float,
+    outlet_rc: Tuple[int, int],
+    mask_basin: np.ndarray,
+    search_radius_cells: int = 4,
+    candidate_thresholds: List[int] | None = None,
+) -> Dict[str, Any]:
+    """Derive a stream network near provided coordinates."""
+
+    if candidate_thresholds is None:
+        vals = acum[mask_basin]
+        if vals.size == 0:
+            raise ValueError("empty basin mask")
+        perc = list(range(99, 79, -1))
+        candidate_thresholds = sorted(
+            {int(np.percentile(vals, p)) for p in perc}, reverse=True
+        )
+
+    seed_info = stream_seed_from_coords(
+        acum,
+        x,
+        y,
+        xll,
+        yll,
+        dx,
+        dy,
+        outlet_rc,
+        search_radius_cells=search_radius_cells,
+    )
+    seed_rc = seed_info["seed_rc"]
+
+    thr = stream_threshold_nearby(acum, seed_rc, flowdir, outlet_rc, candidate_thresholds)
+    stream = stream_find(acum, thr)
+    stream = stream_cut(stream, mask_basin)
+    stream = stream_find_to_corr(stream, flowdir, outlet_rc)
+
+    return {"stream": stream.astype(bool), "threshold": thr, "seed_rc": seed_rc}
+
+
+# ---------------------------------------------------------------------------
 # Network nodes and segmentation
 # ---------------------------------------------------------------------------
 

--- a/wmf_py/utils/config.py
+++ b/wmf_py/utils/config.py
@@ -1,0 +1,78 @@
+"""Configuration helpers for the WMF pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+try:  # PyYAML is optional; keep tests lightweight
+    import yaml
+except Exception:  # pragma: no cover - fallback when yaml missing
+    yaml = None  # type: ignore
+
+
+@dataclass
+class SeedCoords:
+    x: float
+    y: float
+    search_radius_cells: int = 4
+
+
+@dataclass
+class StreamsConfig:
+    candidate_thresholds: Optional[List[int]] = None
+
+
+@dataclass
+class OutputsConfig:
+    hdnd: bool = True
+    aquien: bool = True
+
+
+@dataclass
+class Config:
+    seed_coords: Optional[SeedCoords] = None
+    streams: StreamsConfig = StreamsConfig()
+    outputs: OutputsConfig = OutputsConfig()
+
+
+def load_config(path: str) -> Config:
+    """Load configuration from a YAML file."""
+
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load configuration")
+
+    with open(path, "r", encoding="utf8") as f:
+        data: Dict[str, Any] = yaml.safe_load(f) or {}
+
+    seed = data.get("seed_coords")
+    seed_cfg = None
+    if seed is not None:
+        seed_cfg = SeedCoords(
+            x=float(seed.get("x", 0.0)),
+            y=float(seed.get("y", 0.0)),
+            search_radius_cells=int(seed.get("search_radius_cells", 4)),
+        )
+
+    streams = data.get("streams", {})
+    streams_cfg = StreamsConfig(
+        candidate_thresholds=streams.get("candidate_thresholds")
+    )
+
+    outputs = data.get("outputs", {})
+    outputs_cfg = OutputsConfig(
+        hdnd=bool(outputs.get("hdnd", False)),
+        aquien=bool(outputs.get("aquien", False)),
+    )
+
+    return Config(seed_coords=seed_cfg, streams=streams_cfg, outputs=outputs_cfg)
+
+
+__all__ = [
+    "SeedCoords",
+    "StreamsConfig",
+    "OutputsConfig",
+    "Config",
+    "load_config",
+]
+


### PR DESCRIPTION
## Summary
- add utilities to seed stream networks from approximate coordinates and select thresholds that preserve outlet connectivity
- implement hydrologic distance and receiver calculation and expose configuration helpers and pipeline wrappers
- expand tests covering new stream and metric behaviour

## Testing
- `pip install numpy -q` *(fails: Cannot connect to proxy)*
- `pytest -q wmf_py/tests/test_streams.py` *(skipped: could not import 'numpy')*
- `pytest -q wmf_py/tests/test_metrics.py` *(errors: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689934ae04d88325892e98bd3b1f0a1c