### PR TITLE
Implement threshold-based stream network selection with tests

### DIFF
--- a/wmf_py/cu_py/streams.py
+++ b/wmf_py/cu_py/streams.py
@@ -193,6 +193,10 @@ def _connects_to_outlet(
         if not (0 <= r < ny and 0 <= c < nx):
             return False
 
+    # Should never be reached, but keeps the type checker happy and
+    # documents the fact that lack of a path implies disconnection.
+    return False
+
 
 def stream_threshold_nearby(
     acum: np.ndarray,

--- a/wmf_py/tests/test_streams.py
+++ b/wmf_py/tests/test_streams.py
@@ -105,6 +105,16 @@ def test_stream_threshold_nearby_min_feasible():
     assert thr == 5
 
 
+def test_stream_threshold_nearby_seed_missing_raises():
+    """When all thresholds exclude the seed cell a ValueError is raised."""
+    acum = np.array([[5, 4, 3]])
+    flowdir = np.array([[0, 0, 0]])
+    seed_rc = (0, 0)
+    outlet_rc = (0, 2)
+    with pytest.raises(ValueError):
+        streams.stream_threshold_nearby(acum, seed_rc, flowdir, outlet_rc, [7, 6])
+
+
 def test_stream_find_nearby_integration():
     acum = np.array(
         [


### PR DESCRIPTION
## Summary
- clarify outlet connectivity logic in `_connects_to_outlet`
- add regression tests for `stream_threshold_nearby` error handling

## Testing
- `pytest -q wmf_py/tests/test_streams.py` *(fails: no numpy; could not install numpy due to proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68993b9dcb948325bd14c7a8d3c4691d