### PR TITLE
Implement basin stream and hypsometric utilities

### DIFF
--- a/wmf_py/cu_py/metrics.py
+++ b/wmf_py/cu_py/metrics.py
@@ -355,24 +355,332 @@ def hand(
     out = np.maximum(out, 0.0)
     return out
 
-def basin_ppalstream_find(*args, **kwargs):  # pragma: no cover - stub
-    pass
+
+# ---------------------------------------------------------------------------
+# Principal stream utilities
+# ---------------------------------------------------------------------------
+
+# ``_ppal_stream_profile`` stores the most recently computed principal stream
+# profile.  This mimics the behaviour of the original Fortran routines where
+# ``basin_ppalstream_find`` populated a module level array which was later
+# retrieved by ``basin_ppalstream_cut``.
+_ppal_stream_profile: np.ndarray | None = None
 
 
-def basin_ppalstream_cut(*args, **kwargs):  # pragma: no cover - stub
-    pass
+def basin_ppalstream_find(
+    stream: np.ndarray,
+    flowdir: np.ndarray,
+    dem: np.ndarray,
+    dx: float,
+    dy: float,
+    outlet_rc: Tuple[int, int],
+) -> Tuple[int, Tuple[int, int]]:
+    """Locate the principal (longest) stream in a basin.
+
+    Parameters
+    ----------
+    stream : ndarray of bool or int
+        Mask of the stream network.  Non-zero values denote stream cells.
+    flowdir : ndarray of int
+        D8 flow direction codes following the internal convention defined in
+        :mod:`wmf_py.cu_py.basics`.
+    dem : ndarray of float
+        Elevation model used to extract the longitudinal profile.
+    dx, dy : float
+        Cell spacing in ``x`` and ``y`` directions respectively (metres).
+    outlet_rc : tuple of int
+        Row/column index of the basin outlet.
+
+    Returns
+    -------
+    tuple
+        ``(n_cells, start_rc)`` where ``n_cells`` is the number of cells in the
+        identified principal stream and ``start_rc`` the upstream cell where the
+        stream begins.
+
+    Notes
+    -----
+    The function also stores internally the longitudinal profile of the
+    principal stream.  It can be retrieved later using
+    :func:`basin_ppalstream_cut`.
+    """
+
+    global _ppal_stream_profile
+
+    stream_mask = stream.astype(bool)
+    ny, nx = stream_mask.shape
+
+    # ------------------------------------------------------------------
+    # Build downstream pointers restricted to the stream network and
+    # accumulate indegrees for topological ordering.
+    receivers = np.full((ny, nx, 2), -1, dtype=int)
+    indegree = np.zeros((ny, nx), dtype=int)
+
+    for r in range(ny):
+        for c in range(nx):
+            if not stream_mask[r, c]:
+                continue
+            off = _D8.get(int(flowdir[r, c]))
+            if not off:
+                continue
+            rr, cc = r + off[0], c + off[1]
+            if 0 <= rr < ny and 0 <= cc < nx and stream_mask[rr, cc]:
+                receivers[r, c] = (rr, cc)
+                indegree[rr, cc] += 1
+
+    # ------------------------------------------------------------------
+    # Topological order of the stream network (upstream to downstream).
+    order: List[Tuple[int, int]] = []
+    q: deque[Tuple[int, int]] = deque()
+    for r in range(ny):
+        for c in range(nx):
+            if stream_mask[r, c] and indegree[r, c] == 0:
+                q.append((r, c))
+
+    while q:
+        r, c = q.popleft()
+        order.append((r, c))
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            continue
+        indegree[rr, cc] -= 1
+        if indegree[rr, cc] == 0:
+            q.append((rr, cc))
+
+    # ------------------------------------------------------------------
+    # Compute downstream distances for all stream cells using the obtained
+    # order.  Distances are expressed in metres.
+    dist = np.zeros((ny, nx), dtype=float)
+
+    def _step_len(dr: int, dc: int) -> float:
+        if dr == 0 or dc == 0:
+            return dx if dc != 0 else dy
+        return (dx**2 + dy**2) ** 0.5
+
+    for r, c in reversed(order):
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            dist[r, c] = 0.0
+            continue
+        dr, dc = rr - r, cc - c
+        dist[r, c] = dist[rr, cc] + _step_len(dr, dc)
+
+    # Upstream cell corresponding to the maximum downstream distance.
+    start_flat = int(np.argmax(dist))
+    start_rc = divmod(start_flat, nx)
+
+    # ------------------------------------------------------------------
+    # Build longitudinal profile from ``start_rc`` to the outlet.
+    prof_elev: List[float] = []
+    prof_dist: List[float] = []
+    prof_row: List[int] = []
+    prof_col: List[int] = []
+
+    r, c = start_rc
+    cum_dist = 0.0
+    while True:
+        prof_elev.append(float(dem[r, c]))
+        prof_dist.append(cum_dist)
+        prof_row.append(r)
+        prof_col.append(c)
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            break
+        dr, dc = rr - r, cc - c
+        cum_dist += _step_len(dr, dc)
+        r, c = rr, cc
+
+    profile = np.vstack(
+        [
+            np.array(prof_elev, dtype=float),
+            np.array(prof_dist, dtype=float),
+            np.array(prof_row, dtype=int),
+            np.array(prof_col, dtype=int),
+        ]
+    )
+
+    _ppal_stream_profile = profile
+
+    return profile.shape[1], start_rc
 
 
-def basin_ppal_hipsometric(dem_basin: np.ndarray, mask_basin: np.ndarray) -> Dict[str, np.ndarray]:  # pragma: no cover - stub
-    return {"dem": dem_basin, "mask": mask_basin}
+def basin_ppalstream_cut(*args, **kwargs) -> np.ndarray:
+    """Return the principal stream profile computed previously.
+
+    Parameters are accepted for compatibility with the original Fortran
+    routine but are ignored.  The function simply returns a copy of the
+    profile stored by :func:`basin_ppalstream_find`.
+
+    Returns
+    -------
+    ndarray
+        Array with shape ``(4, N)`` containing elevation, cumulative distance
+        and grid coordinates of the principal stream.
+    """
+
+    if _ppal_stream_profile is None:
+        raise RuntimeError("basin_ppalstream_find must be called before cutting")
+    return _ppal_stream_profile.copy()
 
 
-def basin_time_to_out(flowdir: np.ndarray, dx: float, dy: float, slope: np.ndarray, n_manning: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    return slope * 0 + 1.0
+def basin_ppal_hipsometric(
+    dem_basin: np.ndarray, mask_basin: np.ndarray
+) -> Dict[str, np.ndarray]:
+    """Compute basic hypsometric information for a basin.
+
+    The function wraps :func:`hypsometric_points` and :func:`hypsometric_curve`
+    providing both the raw sorted elevations and a binned representation of the
+    curve.
+
+    Parameters
+    ----------
+    dem_basin : ndarray of float
+        Elevation data of the basin.
+    mask_basin : ndarray of bool
+        Basin mask where ``True`` denotes active cells.
+
+    Returns
+    -------
+    dict
+        Dictionary with the keys ``elev_sorted`` and ``area_cum_frac`` holding
+        the point-wise hypsometric data together with the output of
+        :func:`hypsometric_curve` (``elev_bins``, ``area_frac``, ``min``,
+        ``max`` and ``mean_elev``).
+    """
+
+    elev_sorted, area_cum_frac = hypsometric_points(dem_basin, mask_basin)
+    curve = hypsometric_curve(dem_basin, mask_basin)
+    out: Dict[str, np.ndarray] = {
+        "elev_sorted": elev_sorted,
+        "area_cum_frac": area_cum_frac,
+    }
+    out.update(curve)
+    return out
 
 
-def geo_hand(dem: np.ndarray, stream: np.ndarray) -> np.ndarray:  # pragma: no cover - stub
-    return dem - dem.min()
+def basin_time_to_out(
+    flowdir: np.ndarray,
+    dx: float,
+    dy: float,
+    slope: np.ndarray,
+    n_manning: np.ndarray,
+) -> np.ndarray:
+    """Estimate travel time from each cell to the basin outlet.
+
+    The computation follows D8 directions assuming a unit hydraulic radius in
+    Manning's equation.  Cells involved in flow direction loops receive
+    ``NaN`` as travel time.
+    """
+
+    ny, nx = flowdir.shape
+    receivers = np.full((ny, nx, 2), -1, dtype=int)
+    indegree = np.zeros((ny, nx), dtype=int)
+
+    for r in range(ny):
+        for c in range(nx):
+            off = _D8.get(int(flowdir[r, c]))
+            if not off:
+                continue
+            rr, cc = r + off[0], c + off[1]
+            if 0 <= rr < ny and 0 <= cc < nx:
+                receivers[r, c] = (rr, cc)
+                indegree[rr, cc] += 1
+
+    order: List[Tuple[int, int]] = []
+    q: deque[Tuple[int, int]] = deque()
+    for r in range(ny):
+        for c in range(nx):
+            if indegree[r, c] == 0:
+                q.append((r, c))
+
+    while q:
+        r, c = q.popleft()
+        order.append((r, c))
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            continue
+        indegree[rr, cc] -= 1
+        if indegree[rr, cc] == 0:
+            q.append((rr, cc))
+
+    def _cell_len(r: int, c: int, rr: int, cc: int) -> float:
+        dr, dc = rr - r, cc - c
+        if dr == 0 or dc == 0:
+            return dx if dc != 0 else dy
+        return (dx**2 + dy**2) ** 0.5
+
+    vel = (1.0 / np.maximum(n_manning, 1e-6)) * np.sqrt(np.maximum(slope, 0.0))
+    cell_time = np.full((ny, nx), np.nan, dtype=float)
+    for r in range(ny):
+        for c in range(nx):
+            rr, cc = receivers[r, c]
+            if rr == -1:
+                continue
+            length = _cell_len(r, c, rr, cc)
+            v = vel[r, c]
+            if v > 0:
+                cell_time[r, c] = length / v
+
+    time_to_out = np.full((ny, nx), np.nan, dtype=float)
+    for r, c in reversed(order):
+        rr, cc = receivers[r, c]
+        if rr == -1:
+            time_to_out[r, c] = 0.0
+        elif not np.isnan(cell_time[r, c]) and not np.isnan(time_to_out[rr, cc]):
+            time_to_out[r, c] = cell_time[r, c] + time_to_out[rr, cc]
+
+    return time_to_out
+
+
+def geo_hand(dem: np.ndarray, stream: np.ndarray) -> np.ndarray:
+    """Compute Height Above Nearest Drainage (HAND).
+
+    The algorithm performs a breadth-first search starting from all stream
+    cells.  Each cell inherits the elevation of the closest stream cell in
+    terms of grid steps (using the D8 neighbourhood).  The HAND value is the
+    difference between the cell elevation and the inherited base elevation.
+
+    Parameters
+    ----------
+    dem : ndarray of float
+        Digital elevation model.
+    stream : ndarray of bool or int
+        Stream network mask where non-zero values denote stream cells.
+
+    Returns
+    -------
+    ndarray of float
+        Array with HAND values in metres.  Stream cells are assigned ``0``.
+    """
+
+    ny, nx = dem.shape
+    stream_mask = stream.astype(bool)
+    base = np.full_like(dem, np.nan, dtype=float)
+    visited = np.zeros((ny, nx), dtype=bool)
+    q: deque[Tuple[int, int]] = deque()
+
+    for r in range(ny):
+        for c in range(nx):
+            if stream_mask[r, c]:
+                base[r, c] = dem[r, c]
+                visited[r, c] = True
+                q.append((r, c))
+
+    while q:
+        r, c = q.popleft()
+        for dr, dc in _D8.values():
+            rr, cc = r + dr, c + dc
+            if not (0 <= rr < ny and 0 <= cc < nx):
+                continue
+            if visited[rr, cc]:
+                continue
+            base[rr, cc] = base[r, c]
+            visited[rr, cc] = True
+            q.append((rr, cc))
+
+    hand = dem.astype(float) - base
+    hand[stream_mask] = 0.0
+    return hand
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add algorithm to find and store principal stream profile
- compute basin hypsometry statistics
- implement travel time and HAND estimations

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689941643b008325bab0d32eda07d857