### PR TITLE
Remove Fortran build and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ conda activate wmf_env
 
 Alternativamente, puede instalarse mediante Poetry con el archivo `pyproject.toml` para manejo completo de dependencias.
 
+También es posible instalar directamente con `pip`:
+
+```
+pip install .
+```
+
+> Nota: la compilación de archivos Fortran (`*.f90`) ya no es necesaria; todo el paquete se distribuye como código Python puro.
+
 ---
 
 ## Uso básico

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,10 @@
 from pathlib import Path
-from numpy.distutils.core import Extension, setup
+from setuptools import setup
 
-README = Path(__file__).with_name("README.MD")
+
+README = Path(__file__).with_name("README.md")
 long_description = README.read_text(encoding="utf-8") if README.exists() else ""
-library_path = "/opt/homebrew/Cellar/gcc/15.1.0/lib/gcc/15"  # Ruta donde Homebrew instaló libgfortran.dylib
 
-ext_modules = [
-    Extension(
-        name="wmf_heavy.cu",
-        sources=["wmf_heavy/cuencas_heavy.f90"],
-        f2py_options=["--quiet"],
-    ),
-    Extension(
-        name="wmf_heavy.models",
-        sources=["wmf_heavy/Modelos_heavy.f90"],
-        f2py_options=["--quiet"],
-    ),
-]
 
 setup(
     name="wmf_heavy",
@@ -29,10 +17,9 @@ setup(
     license="GPL-3.0-or-later",
     url="https://github.com/uranzea/wmf_heavy",
     packages=["wmf_heavy"],
-    ext_modules=ext_modules,
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Fortran",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
 )
+


### PR DESCRIPTION
## Summary
- stop compiling Fortran sources in setup.py
- document pip install and note Fortran is no longer required

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6899453e5c788325909fdd7f11db77fe