### PR TITLE
Ensure OpenTopo reclassification is idempotent

### DIFF
--- a/wmf_py/cu_py/basics.py
+++ b/wmf_py/cu_py/basics.py
@@ -93,6 +93,8 @@ def _reclass(flowdir: np.ndarray, table: Dict[int, int]) -> np.ndarray:
     vals = np.unique(flowdir)
     valid_ext = set(table.keys())
     valid_internal = set(range(8))
+    if set(int(v) for v in vals).issubset(valid_internal):
+        return flowdir.astype(int, copy=True)
     unknown = {
         int(v)
         for v in vals


### PR DESCRIPTION
## Summary
- avoid reclassifying flow direction arrays that already use internal codes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68994cc1988c83258170d09356a8b87d