### PR TITLE
Provide basin morphology example notebook

### DIFF
--- a/examples/ejemplo_morfologia.ipynb
+++ b/examples/ejemplo_morfologia.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Ejemplo de uso para morfología de cuencas"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["Coloque los archivos `dem.tif` y `dir.tif` dentro de `examples/data` antes de ejecutar este cuaderno."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import rasterio\n",
+    "import matplotlib.pyplot as plt\n",
+    "from wmf_py.cu_py import basics, metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base = Path(\"examples/data\")\n",
+    "if not base.exists():\n",
+    "    base = Path(\"data\")\n",
+    "dem_path = base / \"dem.tif\"\n",
+    "dir_path = base / \"dir.tif\"\n",
+    "\n",
+    "with rasterio.open(dem_path) as dem_src:\n",
+    "    dem = dem_src.read(1)\n",
+    "    transform = dem_src.transform\n",
+    "    nodata = dem_src.nodata\n",
+    "with rasterio.open(dir_path) as dir_src:\n",
+    "    flowdir = dir_src.read(1)\n",
+    "xll = transform[2]\n",
+    "yll = transform[5] + transform[4] * dem.shape[0]\n",
+    "dx = transform[0]\n",
+    "dy = -transform[4]\n",
+    "mask = dem != nodata\n",
+    "outlet_x = xll + 3 * dx + dx / 2\n",
+    "outlet_y = yll + 3 * dy + dy / 2\n",
+    "r0, c0 = basics.basin_find(outlet_x, outlet_y, xll, yll, dx, dy, dem.shape[1], dem.shape[0])\n",
+    "basin = basics.basin_cut(dem, (r0, c0), flowdir, mask)\n",
+    "mask_basin = basin[\"mask\"]\n",
+    "acum = basics.basin_acum(flowdir, mask_basin)\n",
+    "stream_mask = acum >= 1\n",
+    "metrics.basin_ppalstream_find(stream_mask, flowdir, dem, dx, dy, (r0, c0))\n",
+    "profile = metrics.basin_ppalstream_cut()\n",
+    "area_km2 = mask_basin.sum() * dx * dy / 1e6\n",
+    "length_km = profile[1, -1] / 1000.0\n",
+    "slope_pct = np.polyfit(profile[1, ::-1], profile[0], 1)[0] * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Área de la cuenca: {area_km2:.2f} km²\")\n",
+    "print(f\"Longitud del cauce principal: {length_km:.2f} km\")\n",
+    "print(f\"Pendiente media del cauce: {slope_pct:.2f} %\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(dem, cmap=\"terrain\")\n",
+    "plt.contour(mask_basin, levels=[0.5], colors=\"blue\")\n",
+    "plt.title(\"Cuenca delineada\")\n",
+    "plt.axis(\"off\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(mask_basin, cmap=\"Greys\", alpha=0.5)\n",
+    "plt.imshow(np.where(stream_mask, stream_mask, np.nan), cmap=\"Blues\", alpha=0.7)\n",
+    "plt.title(\"Red de drenaje\")\n",
+    "plt.axis(\"off\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(profile[1], profile[0])\n",
+    "plt.xlabel(\"Distancia (m)\")\n",
+    "plt.ylabel(\"Elevación (m)\")\n",
+    "plt.title(\"Perfil longitudinal del cauce principal\")\n",
+    "plt.grid(True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- replace test assets with a Jupyter notebook showing basin delineation and drainage plotting
- drop binary DEM/DIR files and add an empty data directory for user-supplied rasters

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689955303678832580a06fde016f52df